### PR TITLE
feat(application): implement Task CRUD use cases with TDD

### DIFF
--- a/src/main/java/com/taskmanager/api/application/command/ChangeTaskStatusCommand.java
+++ b/src/main/java/com/taskmanager/api/application/command/ChangeTaskStatusCommand.java
@@ -1,0 +1,6 @@
+package com.taskmanager.api.application.command;
+
+import java.util.UUID;
+
+public record ChangeTaskStatusCommand(UUID taskId, TaskStatusAction action) {
+}

--- a/src/main/java/com/taskmanager/api/application/command/CreateTaskCommand.java
+++ b/src/main/java/com/taskmanager/api/application/command/CreateTaskCommand.java
@@ -1,0 +1,6 @@
+package com.taskmanager.api.application.command;
+
+import java.time.LocalDate;
+
+public record CreateTaskCommand(String title, String description, LocalDate dueDate) {
+}

--- a/src/main/java/com/taskmanager/api/application/command/TaskStatusAction.java
+++ b/src/main/java/com/taskmanager/api/application/command/TaskStatusAction.java
@@ -1,0 +1,12 @@
+package com.taskmanager.api.application.command;
+
+/**
+ * Application-level vocabulary for the status transitions a client may request.
+ * Kept separate from {@code TaskStatus} (the domain's state) because "what the caller
+ * asks for" and "what state the aggregate ends up in" are different concerns.
+ */
+public enum TaskStatusAction {
+    START,
+    COMPLETE,
+    REOPEN
+}

--- a/src/main/java/com/taskmanager/api/application/command/UpdateTaskCommand.java
+++ b/src/main/java/com/taskmanager/api/application/command/UpdateTaskCommand.java
@@ -1,0 +1,7 @@
+package com.taskmanager.api.application.command;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record UpdateTaskCommand(UUID taskId, String title, String description, LocalDate dueDate) {
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/ChangeTaskStatusService.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/ChangeTaskStatusService.java
@@ -1,0 +1,35 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.ChangeTaskStatusCommand;
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+
+@Service
+public class ChangeTaskStatusService implements ChangeTaskStatusUseCase {
+
+    private final TaskRepository taskRepository;
+    private final Clock clock;
+
+    public ChangeTaskStatusService(TaskRepository taskRepository, Clock clock) {
+        this.taskRepository = taskRepository;
+        this.clock = clock;
+    }
+
+    @Override
+    public Task execute(ChangeTaskStatusCommand command) {
+        Task task = taskRepository.findById(command.taskId())
+                .orElseThrow(() -> new TaskNotFoundException(command.taskId()));
+
+        Task transitioned = switch (command.action()) {
+            case START -> task.start(clock);
+            case COMPLETE -> task.complete(clock);
+            case REOPEN -> task.reopen(clock);
+        };
+
+        return taskRepository.save(transitioned);
+    }
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/ChangeTaskStatusUseCase.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/ChangeTaskStatusUseCase.java
@@ -1,0 +1,7 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.ChangeTaskStatusCommand;
+import com.taskmanager.api.domain.model.Task;
+
+public interface ChangeTaskStatusUseCase extends UseCase<ChangeTaskStatusCommand, Task> {
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/CreateTaskService.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/CreateTaskService.java
@@ -1,0 +1,26 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.CreateTaskCommand;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+
+@Service
+public class CreateTaskService implements CreateTaskUseCase {
+
+    private final TaskRepository taskRepository;
+    private final Clock clock;
+
+    public CreateTaskService(TaskRepository taskRepository, Clock clock) {
+        this.taskRepository = taskRepository;
+        this.clock = clock;
+    }
+
+    @Override
+    public Task execute(CreateTaskCommand command) {
+        Task task = Task.create(command.title(), command.description(), command.dueDate(), clock);
+        return taskRepository.save(task);
+    }
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/CreateTaskUseCase.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/CreateTaskUseCase.java
@@ -1,0 +1,7 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.CreateTaskCommand;
+import com.taskmanager.api.domain.model.Task;
+
+public interface CreateTaskUseCase extends UseCase<CreateTaskCommand, Task> {
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/DeleteTaskService.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/DeleteTaskService.java
@@ -1,0 +1,25 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class DeleteTaskService implements DeleteTaskUseCase {
+
+    private final TaskRepository taskRepository;
+
+    public DeleteTaskService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public void execute(UUID taskId) {
+        if (!taskRepository.existsById(taskId)) {
+            throw new TaskNotFoundException(taskId);
+        }
+        taskRepository.deleteById(taskId);
+    }
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/DeleteTaskUseCase.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/DeleteTaskUseCase.java
@@ -1,0 +1,8 @@
+package com.taskmanager.api.application.usecase;
+
+import java.util.UUID;
+
+public interface DeleteTaskUseCase {
+
+    void execute(UUID taskId);
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/GetTaskService.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/GetTaskService.java
@@ -1,0 +1,24 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class GetTaskService implements GetTaskUseCase {
+
+    private final TaskRepository taskRepository;
+
+    public GetTaskService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public Task execute(UUID taskId) {
+        return taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskNotFoundException(taskId));
+    }
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/GetTaskUseCase.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/GetTaskUseCase.java
@@ -1,0 +1,8 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.domain.model.Task;
+
+import java.util.UUID;
+
+public interface GetTaskUseCase extends UseCase<UUID, Task> {
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/ListTasksService.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/ListTasksService.java
@@ -1,0 +1,22 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ListTasksService implements ListTasksUseCase {
+
+    private final TaskRepository taskRepository;
+
+    public ListTasksService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public List<Task> execute() {
+        return taskRepository.findAll();
+    }
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/ListTasksUseCase.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/ListTasksUseCase.java
@@ -1,0 +1,10 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.domain.model.Task;
+
+import java.util.List;
+
+public interface ListTasksUseCase {
+
+    List<Task> execute();
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/UpdateTaskService.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/UpdateTaskService.java
@@ -1,0 +1,30 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.UpdateTaskCommand;
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+
+@Service
+public class UpdateTaskService implements UpdateTaskUseCase {
+
+    private final TaskRepository taskRepository;
+    private final Clock clock;
+
+    public UpdateTaskService(TaskRepository taskRepository, Clock clock) {
+        this.taskRepository = taskRepository;
+        this.clock = clock;
+    }
+
+    @Override
+    public Task execute(UpdateTaskCommand command) {
+        Task existing = taskRepository.findById(command.taskId())
+                .orElseThrow(() -> new TaskNotFoundException(command.taskId()));
+
+        Task updated = existing.updateDetails(command.title(), command.description(), command.dueDate(), clock);
+        return taskRepository.save(updated);
+    }
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/UpdateTaskUseCase.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/UpdateTaskUseCase.java
@@ -1,0 +1,7 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.UpdateTaskCommand;
+import com.taskmanager.api.domain.model.Task;
+
+public interface UpdateTaskUseCase extends UseCase<UpdateTaskCommand, Task> {
+}

--- a/src/main/java/com/taskmanager/api/application/usecase/UseCase.java
+++ b/src/main/java/com/taskmanager/api/application/usecase/UseCase.java
@@ -1,0 +1,11 @@
+package com.taskmanager.api.application.usecase;
+
+/**
+ * A single application operation: takes one input, produces one output.
+ * Each use case is a class with one reason to change (Single Responsibility),
+ * and depends only on domain ports (Dependency Inversion).
+ */
+public interface UseCase<IN, OUT> {
+
+    OUT execute(IN input);
+}

--- a/src/test/java/com/taskmanager/api/application/usecase/ChangeTaskStatusServiceTest.java
+++ b/src/test/java/com/taskmanager/api/application/usecase/ChangeTaskStatusServiceTest.java
@@ -1,0 +1,93 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.ChangeTaskStatusCommand;
+import com.taskmanager.api.application.command.TaskStatusAction;
+import com.taskmanager.api.domain.exception.InvalidTaskStatusTransitionException;
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.model.TaskStatus;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChangeTaskStatusServiceTest {
+
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-08-18T10:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    private ChangeTaskStatusUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ChangeTaskStatusService(taskRepository, FIXED_CLOCK);
+    }
+
+    @Test
+    void startsATodoTask() {
+        Task task = Task.create("Task", null, null, FIXED_CLOCK);
+        when(taskRepository.findById(task.id())).thenReturn(Optional.of(task));
+        when(taskRepository.save(any(Task.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Task result = useCase.execute(new ChangeTaskStatusCommand(task.id(), TaskStatusAction.START));
+
+        assertThat(result.status()).isEqualTo(TaskStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void completesATask() {
+        Task task = Task.create("Task", null, null, FIXED_CLOCK);
+        when(taskRepository.findById(task.id())).thenReturn(Optional.of(task));
+        when(taskRepository.save(any(Task.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Task result = useCase.execute(new ChangeTaskStatusCommand(task.id(), TaskStatusAction.COMPLETE));
+
+        assertThat(result.status()).isEqualTo(TaskStatus.DONE);
+    }
+
+    @Test
+    void reopensADoneTask() {
+        Task task = Task.create("Task", null, null, FIXED_CLOCK).complete(FIXED_CLOCK);
+        when(taskRepository.findById(task.id())).thenReturn(Optional.of(task));
+        when(taskRepository.save(any(Task.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Task result = useCase.execute(new ChangeTaskStatusCommand(task.id(), TaskStatusAction.REOPEN));
+
+        assertThat(result.status()).isEqualTo(TaskStatus.TODO);
+    }
+
+    @Test
+    void propagatesInvalidTransition() {
+        Task task = Task.create("Task", null, null, FIXED_CLOCK).complete(FIXED_CLOCK);
+        when(taskRepository.findById(task.id())).thenReturn(Optional.of(task));
+
+        assertThatThrownBy(() -> useCase.execute(new ChangeTaskStatusCommand(task.id(), TaskStatusAction.START)))
+                .isInstanceOf(InvalidTaskStatusTransitionException.class);
+    }
+
+    @Test
+    void throwsWhenTaskDoesNotExist() {
+        UUID id = UUID.randomUUID();
+        when(taskRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(new ChangeTaskStatusCommand(id, TaskStatusAction.START)))
+                .isInstanceOf(TaskNotFoundException.class);
+    }
+}

--- a/src/test/java/com/taskmanager/api/application/usecase/CreateTaskServiceTest.java
+++ b/src/test/java/com/taskmanager/api/application/usecase/CreateTaskServiceTest.java
@@ -1,0 +1,61 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.CreateTaskCommand;
+import com.taskmanager.api.domain.exception.InvalidTaskException;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateTaskServiceTest {
+
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-08-18T10:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    private CreateTaskUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateTaskService(taskRepository, FIXED_CLOCK);
+    }
+
+    @Test
+    void createsTaskAndPersistsIt() {
+        when(taskRepository.save(any(Task.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Task result = useCase.execute(new CreateTaskCommand("Write tests", "Follow TDD", LocalDate.of(2026, 9, 1)));
+
+        assertThat(result.title()).isEqualTo("Write tests");
+        assertThat(result.description()).isEqualTo("Follow TDD");
+        assertThat(result.dueDate()).isEqualTo(LocalDate.of(2026, 9, 1));
+
+        ArgumentCaptor<Task> captor = ArgumentCaptor.forClass(Task.class);
+        verify(taskRepository).save(captor.capture());
+        assertThat(captor.getValue().title()).isEqualTo("Write tests");
+    }
+
+    @Test
+    void propagatesDomainValidationFailure() {
+        assertThatThrownBy(() -> useCase.execute(new CreateTaskCommand("", "desc", null)))
+                .isInstanceOf(InvalidTaskException.class);
+    }
+}

--- a/src/test/java/com/taskmanager/api/application/usecase/DeleteTaskServiceTest.java
+++ b/src/test/java/com/taskmanager/api/application/usecase/DeleteTaskServiceTest.java
@@ -1,0 +1,48 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteTaskServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    private DeleteTaskUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new DeleteTaskService(taskRepository);
+    }
+
+    @Test
+    void deletesExistingTask() {
+        UUID id = UUID.randomUUID();
+        when(taskRepository.existsById(id)).thenReturn(true);
+
+        useCase.execute(id);
+
+        verify(taskRepository).deleteById(id);
+    }
+
+    @Test
+    void throwsWhenTaskDoesNotExist() {
+        UUID id = UUID.randomUUID();
+        when(taskRepository.existsById(id)).thenReturn(false);
+
+        assertThatThrownBy(() -> useCase.execute(id))
+                .isInstanceOf(TaskNotFoundException.class);
+    }
+}

--- a/src/test/java/com/taskmanager/api/application/usecase/GetTaskServiceTest.java
+++ b/src/test/java/com/taskmanager/api/application/usecase/GetTaskServiceTest.java
@@ -1,0 +1,51 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetTaskServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    private GetTaskUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetTaskService(taskRepository);
+    }
+
+    @Test
+    void returnsTaskWhenFound() {
+        Task task = Task.create("Task", null, null, Clock.systemUTC());
+        when(taskRepository.findById(task.id())).thenReturn(Optional.of(task));
+
+        Task result = useCase.execute(task.id());
+
+        assertThat(result).isEqualTo(task);
+    }
+
+    @Test
+    void throwsWhenTaskDoesNotExist() {
+        UUID id = UUID.randomUUID();
+        when(taskRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(id))
+                .isInstanceOf(TaskNotFoundException.class);
+    }
+}

--- a/src/test/java/com/taskmanager/api/application/usecase/ListTasksServiceTest.java
+++ b/src/test/java/com/taskmanager/api/application/usecase/ListTasksServiceTest.java
@@ -1,0 +1,47 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ListTasksServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    private ListTasksUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ListTasksService(taskRepository);
+    }
+
+    @Test
+    void returnsAllTasksFromRepository() {
+        Task first = Task.create("First", null, null, Clock.systemUTC());
+        Task second = Task.create("Second", null, null, Clock.systemUTC());
+        when(taskRepository.findAll()).thenReturn(List.of(first, second));
+
+        List<Task> result = useCase.execute();
+
+        assertThat(result).containsExactly(first, second);
+    }
+
+    @Test
+    void returnsEmptyListWhenNoTasksExist() {
+        when(taskRepository.findAll()).thenReturn(List.of());
+
+        assertThat(useCase.execute()).isEmpty();
+    }
+}

--- a/src/test/java/com/taskmanager/api/application/usecase/UpdateTaskServiceTest.java
+++ b/src/test/java/com/taskmanager/api/application/usecase/UpdateTaskServiceTest.java
@@ -1,0 +1,62 @@
+package com.taskmanager.api.application.usecase;
+
+import com.taskmanager.api.application.command.UpdateTaskCommand;
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateTaskServiceTest {
+
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-08-18T10:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    private UpdateTaskUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new UpdateTaskService(taskRepository, FIXED_CLOCK);
+    }
+
+    @Test
+    void updatesExistingTaskDetails() {
+        Task existing = Task.create("Original", "Original desc", null, FIXED_CLOCK);
+        when(taskRepository.findById(existing.id())).thenReturn(Optional.of(existing));
+        when(taskRepository.save(any(Task.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Task result = useCase.execute(new UpdateTaskCommand(existing.id(), "New title", "New desc", LocalDate.of(2026, 10, 1)));
+
+        assertThat(result.title()).isEqualTo("New title");
+        assertThat(result.description()).isEqualTo("New desc");
+        assertThat(result.dueDate()).isEqualTo(LocalDate.of(2026, 10, 1));
+    }
+
+    @Test
+    void throwsWhenTaskDoesNotExist() {
+        UUID id = UUID.randomUUID();
+        when(taskRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(new UpdateTaskCommand(id, "Title", null, null)))
+                .isInstanceOf(TaskNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## What
Implements the application layer: one use case class per Task operation, each depending only on the `TaskRepository` port, built test-first with Mockito.

## Related issues
Closes #4

## Changes
- Application layer use cases (`UseCase<IN, OUT>` implementations): `CreateTaskService`, `GetTaskService`, `ListTasksService`, `UpdateTaskService`, `DeleteTaskService`, `ChangeTaskStatusService`, each with a matching port interface (`CreateTaskUseCase`, `GetTaskUseCase`, etc.)
- Command records: `CreateTaskCommand`, `UpdateTaskCommand`, `ChangeTaskStatusCommand`, and the `TaskStatusAction` enum
- No dependency beyond the domain-layer `TaskRepository` port — infrastructure is not yet wired in

## Testing
Unit tests per use case (`CreateTaskServiceTest`, `GetTaskServiceTest`, `ListTasksServiceTest`, `UpdateTaskServiceTest`, `DeleteTaskServiceTest`, `ChangeTaskStatusServiceTest`) using plain JUnit 5 + Mockito, no Spring context. `./mvnw clean test` passes (30/30 across domain + application layers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
