### PR TITLE
feat(infrastructure): implement persistence adapter with JPA and Testcontainers

### DIFF
--- a/src/main/java/com/taskmanager/api/infrastructure/config/ClockConfig.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/config/ClockConfig.java
@@ -1,0 +1,20 @@
+package com.taskmanager.api.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+/**
+ * Exposes the system clock as a bean so application-layer classes depend on an
+ * injectable {@link Clock} instead of calling {@code Instant.now()} directly -
+ * this is what lets use case tests use a fixed clock deterministically.
+ */
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/persistence/TaskJpaRepository.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/persistence/TaskJpaRepository.java
@@ -1,0 +1,9 @@
+package com.taskmanager.api.infrastructure.persistence;
+
+import com.taskmanager.api.infrastructure.persistence.entity.TaskJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+interface TaskJpaRepository extends JpaRepository<TaskJpaEntity, UUID> {
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/persistence/TaskRepositoryAdapter.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/persistence/TaskRepositoryAdapter.java
@@ -1,0 +1,53 @@
+package com.taskmanager.api.infrastructure.persistence;
+
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.repository.TaskRepository;
+import com.taskmanager.api.infrastructure.persistence.mapper.TaskPersistenceMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Outbound adapter that implements the domain {@link TaskRepository} port on top of
+ * Spring Data JPA. This is the only class in the codebase allowed to depend on both
+ * the domain model and the JPA-specific persistence types.
+ */
+@Component
+public class TaskRepositoryAdapter implements TaskRepository {
+
+    private final TaskJpaRepository taskJpaRepository;
+
+    public TaskRepositoryAdapter(TaskJpaRepository taskJpaRepository) {
+        this.taskJpaRepository = taskJpaRepository;
+    }
+
+    @Override
+    public Task save(Task task) {
+        var saved = taskJpaRepository.save(TaskPersistenceMapper.toEntity(task));
+        return TaskPersistenceMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<Task> findById(UUID id) {
+        return taskJpaRepository.findById(id).map(TaskPersistenceMapper::toDomain);
+    }
+
+    @Override
+    public List<Task> findAll() {
+        return taskJpaRepository.findAll().stream()
+                .map(TaskPersistenceMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        taskJpaRepository.deleteById(id);
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return taskJpaRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/persistence/entity/TaskJpaEntity.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/persistence/entity/TaskJpaEntity.java
@@ -1,0 +1,90 @@
+package com.taskmanager.api.infrastructure.persistence.entity;
+
+import com.taskmanager.api.domain.model.TaskStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * JPA record for the {@code tasks} table. Deliberately separate from the domain
+ * {@code Task} aggregate: this class exists to satisfy Hibernate (mutable, no-arg
+ * constructor, framework annotations) and must never leak outside the persistence
+ * package - {@link com.taskmanager.api.infrastructure.persistence.mapper.TaskPersistenceMapper}
+ * is the only thing allowed to translate to/from the domain model.
+ */
+@Entity
+@Table(name = "tasks")
+public class TaskJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TaskStatus status;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected TaskJpaEntity() {
+        // required by JPA
+    }
+
+    public TaskJpaEntity(UUID id, String title, String description, TaskStatus status,
+                          LocalDate dueDate, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.status = status;
+        this.dueDate = dueDate;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public TaskStatus getStatus() {
+        return status;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/persistence/mapper/TaskPersistenceMapper.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/persistence/mapper/TaskPersistenceMapper.java
@@ -1,0 +1,39 @@
+package com.taskmanager.api.infrastructure.persistence.mapper;
+
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.infrastructure.persistence.entity.TaskJpaEntity;
+
+/**
+ * Translates between the domain {@link Task} aggregate and the {@link TaskJpaEntity}
+ * persistence record. Nothing outside the persistence package should ever see a
+ * {@code TaskJpaEntity} - this mapper is the boundary.
+ */
+public final class TaskPersistenceMapper {
+
+    private TaskPersistenceMapper() {
+    }
+
+    public static TaskJpaEntity toEntity(Task task) {
+        return new TaskJpaEntity(
+                task.id(),
+                task.title(),
+                task.description(),
+                task.status(),
+                task.dueDate(),
+                task.createdAt(),
+                task.updatedAt()
+        );
+    }
+
+    public static Task toDomain(TaskJpaEntity entity) {
+        return Task.reconstruct(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getDescription(),
+                entity.getStatus(),
+                entity.getDueDate(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/src/test/java/com/taskmanager/api/infrastructure/AbstractPostgresIntegrationTest.java
+++ b/src/test/java/com/taskmanager/api/infrastructure/AbstractPostgresIntegrationTest.java
@@ -1,0 +1,23 @@
+package com.taskmanager.api.infrastructure;
+
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Base class for integration tests that need a real PostgreSQL instance.
+ *
+ * <p>The container is started once per JVM and shared across every subclass, since the
+ * static field is inherited rather than redeclared - this keeps the test suite fast even
+ * as more integration tests are added.
+ */
+@Testcontainers
+public abstract class AbstractPostgresIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer POSTGRES =
+            new PostgreSQLContainer(DockerImageName.parse("postgres:16-alpine"));
+}

--- a/src/test/java/com/taskmanager/api/infrastructure/persistence/TaskRepositoryAdapterTest.java
+++ b/src/test/java/com/taskmanager/api/infrastructure/persistence/TaskRepositoryAdapterTest.java
@@ -1,0 +1,107 @@
+package com.taskmanager.api.infrastructure.persistence;
+
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.model.TaskStatus;
+import com.taskmanager.api.infrastructure.AbstractPostgresIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class TaskRepositoryAdapterTest extends AbstractPostgresIntegrationTest {
+
+    @Autowired
+    private TaskJpaRepository taskJpaRepository;
+
+    private TaskRepositoryAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new TaskRepositoryAdapter(taskJpaRepository);
+    }
+
+    @Test
+    void savesAndRetrievesATaskById() {
+        Task task = Task.create("Buy groceries", "Milk, eggs, bread", LocalDate.of(2026, 9, 1), Clock.systemUTC());
+
+        adapter.save(task);
+        Optional<Task> found = adapter.findById(task.id());
+
+        assertThat(found).isPresent();
+        assertRoundTripsCorrectly(task, found.get());
+    }
+
+    @Test
+    void returnsEmptyWhenTaskDoesNotExist() {
+        assertThat(adapter.findById(UUID.randomUUID())).isEmpty();
+    }
+
+    @Test
+    void findsAllPersistedTasks() {
+        Task first = Task.create("First", null, null, Clock.systemUTC());
+        Task second = Task.create("Second", null, null, Clock.systemUTC());
+        adapter.save(first);
+        adapter.save(second);
+
+        List<Task> all = adapter.findAll();
+
+        assertThat(all).extracting(Task::id).containsExactlyInAnyOrder(first.id(), second.id());
+    }
+
+    @Test
+    void updatesAnExistingTaskOnSave() {
+        Task task = Task.create("Original", null, null, Clock.systemUTC());
+        adapter.save(task);
+
+        Task started = task.start(Clock.systemUTC());
+        adapter.save(started);
+
+        Optional<Task> found = adapter.findById(task.id());
+        assertThat(found).isPresent();
+        assertThat(found.get().status()).isEqualTo(TaskStatus.IN_PROGRESS);
+        assertThat(adapter.findAll()).hasSize(1);
+    }
+
+    @Test
+    void deletesATask() {
+        Task task = Task.create("To delete", null, null, Clock.systemUTC());
+        adapter.save(task);
+
+        adapter.deleteById(task.id());
+
+        assertThat(adapter.findById(task.id())).isEmpty();
+    }
+
+    @Test
+    void reportsWhetherATaskExists() {
+        Task task = Task.create("Existing", null, null, Clock.systemUTC());
+        adapter.save(task);
+
+        assertThat(adapter.existsById(task.id())).isTrue();
+        assertThat(adapter.existsById(UUID.randomUUID())).isFalse();
+    }
+
+    private void assertRoundTripsCorrectly(Task expected, Task actual) {
+        assertThat(actual.id()).isEqualTo(expected.id());
+        assertThat(actual.title()).isEqualTo(expected.title());
+        assertThat(actual.description()).isEqualTo(expected.description());
+        assertThat(actual.status()).isEqualTo(expected.status());
+        assertThat(actual.dueDate()).isEqualTo(expected.dueDate());
+        assertThat(actual.createdAt().truncatedTo(ChronoUnit.MILLIS))
+                .isEqualTo(expected.createdAt().truncatedTo(ChronoUnit.MILLIS));
+        assertThat(actual.updatedAt().truncatedTo(ChronoUnit.MILLIS))
+                .isEqualTo(expected.updatedAt().truncatedTo(ChronoUnit.MILLIS));
+    }
+}


### PR DESCRIPTION
## What
Implements the persistence adapter for the `TaskRepository` port, backed by JPA/Hibernate against real PostgreSQL, verified with Testcontainers.

## Related issues
Closes #5

## Changes
- Infrastructure/persistence: `TaskJpaEntity`, package-private `TaskJpaRepository` (Spring Data JPA), `TaskRepositoryAdapter` implementing the domain `TaskRepository` port, and `TaskPersistenceMapper` to translate between `Task` (domain) and `TaskJpaEntity` (JPA) — the two types never cross the layer boundary directly
- `ClockConfig`: injectable `Clock` bean so timestamps are testable
- `AbstractPostgresIntegrationTest`: shared Testcontainers base class (static container field, reused across subclasses in the same JVM)

## Testing
`TaskRepositoryAdapterTest` (6 tests) runs against real PostgreSQL via Testcontainers, exercising the `V1__create_tasks_table.sql` Flyway migration for real. `./mvnw clean test` passes (36/36 across domain, application, and persistence layers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
