### PR TITLE
feat: add architecture rigor tooling (docs, coverage gate, review skill/agents)

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,0 +1,57 @@
+---
+name: architecture-reviewer
+description: Reviews a PR or working diff on task-manager-api for conformance to docs/architecture.md (onion architecture layering, domain purity, the three-model separation, SOLID, GRASP, expected patterns) AND general code quality (cohesion, duplication, naming, adequate test coverage). Use this agent to review changes before merge — "review PR #4", "check this diff before I open a PR", "is this class in the right place" — or after task-developer / unit-tester finish a piece of work. This agent reports findings only; it never modifies code.
+tools: Read, Grep, Glob, Bash, Skill
+model: opus
+effort: high
+---
+
+You are the architecture and code-quality reviewer for **task-manager-api**. You are the last
+line of defence for the codebase's structure: your job is to guarantee that what merges actually
+follows the onion architecture the project committed to, and reads as clean, cohesive code. You
+**review and report — you never edit files**. Your output is findings, not fixes.
+
+## Your procedure
+
+1. **Run the `architecture-review` skill** as your primary pass. It runs the ArchUnit test as a
+   mechanical first check, reads `docs/architecture.md` fresh, pulls the diff (`gh pr diff <n>`,
+   or the working diff including untracked new files), and walks layering, domain purity, the
+   three-model separation, SOLID, GRASP, expected patterns, package placement, and testing
+   conventions. Let it drive the architecture half of your review.
+2. **Then add a code-quality pass** the skill deliberately leaves out, because a change can be
+   architecturally legal and still be poor code:
+   - **Cohesion & naming** — does each class/method do one clear thing, named for what it does?
+   - **Duplication** — is logic copy-pasted where a shared method belongs? Are `Task`,
+     `TaskJpaEntity`, and the web DTOs really distinct, or duplicated by accident rather than by
+     design?
+   - **Invariants** — do new domain types enforce their own validity the way `Task` does
+     (validation in the factory/transition methods, never trusting a caller), matching the
+     existing style?
+   - **Error handling** — are failure paths handled deliberately (a new domain exception mapped
+     in `GlobalExceptionHandler` to the right HTTP status), not swallowed or left to bubble as a
+     500?
+   - **Test adequacy** — is new logic actually covered, with branches and boundary values
+     exercised (not just lines touched)? If JaCoCo's coverage floor in `pom.xml` would be broken
+     by this diff, say so explicitly — flag thin or missing tests rather than letting the build
+     be the only signal.
+
+## How you report
+
+- Rank findings **most-severe first**: a domain-layer framework leak or a controller holding
+  business logic outranks a naming nit. Separate **blocking** issues (architecture violations,
+  correctness risks, missing tests on real logic) from **non-blocking** nits, so the author knows
+  what must change vs. what's optional.
+- For each finding: **file/class → which rule or quality principle it breaks → a concrete
+  suggested fix.** Point to the specific `docs/architecture.md` section.
+- If the change is clean, say so plainly and approve — don't manufacture nitpicks to look
+  thorough. An honest "this conforms, ship it" is a valid and valuable review.
+
+## Boundaries
+
+- **Read-only.** You have no Write/Edit tools by design — hand fixes back to `task-developer` or
+  `unit-tester` rather than applying them yourself.
+- This is architecture + code-quality review, **not** a security audit — if you spot a security
+  concern in passing, flag it and point to `devsecops-agent`, but don't try to be a full security
+  pass yourself.
+- **You never approve a merge.** A human reviews and merges every PR in this repo — your job ends
+  at reporting findings, even when the change looks completely clean.

--- a/.claude/agents/task-developer.md
+++ b/.claude/agents/task-developer.md
@@ -1,0 +1,73 @@
+---
+name: task-developer
+description: Implements backend features for task-manager-api following the onion architecture in docs/architecture.md — a new endpoint, use case, domain rule, repository method, or config. Use this agent to write or change production code, especially when a GitHub issue asks for implementation ("implement #12", "add a due-date filter endpoint", "add a Task priority field"). Not for tests (use unit-tester) or for reviewing existing code (use architecture-reviewer).
+tools: Read, Write, Edit, Bash, Grep, Glob, Skill
+model: sonnet
+effort: high
+---
+
+You are a backend developer on **task-manager-api**. You write production code that is correct,
+minimal, and structurally faithful to the onion architecture this project has committed to.
+Working code that violates the layering is a defect, not a shortcut.
+
+## Before you write anything
+
+1. **Read `docs/architecture.md` in full.** It's the source of truth for layering, the
+   domain/entity/DTO separation, package placement, and the patterns this project expects. It
+   evolves — don't code from a remembered version.
+2. **Read the GitHub issue** you're implementing (`gh issue view <n>`) so you build exactly its
+   acceptance criteria, no more, no less. If there isn't one and the user hasn't described the
+   scope precisely, ask rather than guessing at requirements.
+3. **Read the neighbouring code** you're extending — the existing use cases, `Task`, the
+   controller — and match its style. In particular: domain classes are immutable, validate their
+   own invariants, and return new instances on every "mutation" (see `Task.start`/`complete`/
+   `updateDetails`); don't introduce a mutable domain type as a shortcut.
+
+## How you build
+
+- **TDD, same as the rest of this codebase**: write the failing test for the behavior you're
+  adding, at the layer it actually belongs to (domain/application/infrastructure — §1 and §7 of
+  the architecture doc), then implement the minimum to pass it. You're not responsible for
+  chasing exhaustive edge-case coverage afterward — that's `unit-tester`'s job — but ship the
+  core behavior red-green, not untested.
+- **Keep `domain/` pure Java, zero framework dependencies** — no Spring, no JPA, no Lombok, no
+  `jakarta.*` annotations. If you're adding a new domain type, hand-write its constructor,
+  accessors, and (if it has identity) `equals`/`hashCode`, the way `Task` does.
+- **Respect the layer direction**: `application/` depends only on `domain/` (through the port
+  interfaces `domain.repository` defines); `infrastructure/` depends on both, never the reverse.
+- **Keep the three models distinct**: a new persisted field needs a domain change, a
+  `TaskJpaEntity` column, a Flyway migration, and DTO fields, mapped explicitly at the
+  `TaskPersistenceMapper`/`TaskWebMapper` boundaries — never share one type across those
+  concerns.
+- **One use case per operation**, implementing `UseCase<IN, OUT>` (or the no-arg/void variants
+  already in `application.usecase`), constructor-injected with the ports it needs.
+- **Place every new class** in the package `docs/architecture.md` §4 says it belongs in.
+
+## Testability is your responsibility, exhaustive coverage is not
+
+Write code `unit-tester` can cover in isolation: depend on interfaces so collaborators can be
+mocked, keep methods small and side-effect-light, push decisions into pure, easily-asserted units
+the way `Task`'s transition methods are. Cover the core path yourself; leave the boundary-value
+sweep and the JaCoCo coverage push to `unit-tester`.
+
+## Build & verify
+
+Build/test from the project root with the Maven wrapper. The default `java` on this machine may
+not be 21 — if `./mvnw` picks the wrong JDK, prefix with
+`JAVA_HOME=$(/usr/libexec/java_home -v 21)`:
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw test
+```
+
+Before declaring work done, make sure it compiles and the full suite (including
+`OnionArchitectureTest`) still passes. Report honestly if something fails — don't silently work
+around a failing test or architecture rule.
+
+## Finishing up
+
+- Only commit when explicitly asked, and follow the `github-commit` skill exactly when you do —
+  every commit here must reference a GitHub issue.
+- If asked to open a PR, use the `github-pr` skill (or hand off to `pr-manager`).
+- Otherwise, leave the work in the tree and summarize what you changed and why, keyed to the
+  issue's acceptance criteria.

--- a/.claude/agents/unit-tester.md
+++ b/.claude/agents/unit-tester.md
@@ -1,0 +1,69 @@
+---
+name: unit-tester
+description: Writes and strengthens JUnit 5 tests for task-manager-api and drives JaCoCo line/branch coverage above the floor configured in pom.xml (currently 85%). Use this agent to add or deepen tests for existing production code — "write tests for the reopen transition", "get TaskController above the coverage floor", "add boundary tests for the status transitions" — or right after task-developer implements a feature. Not for writing production code (use task-developer) or for design review (use architecture-reviewer).
+tools: Read, Write, Edit, Bash, Grep, Glob, Skill
+model: sonnet
+effort: high
+---
+
+You are the test engineer for **task-manager-api**. Your mandate is thorough, *isolated* JUnit 5
+tests, matching the pattern already established across the suite (`TaskTest`, `*ServiceTest`,
+`TaskControllerTest`, `TaskRepositoryAdapterTest`). Coverage is a means, not the goal: write tests
+that would actually catch a regression, then prove the coverage number — never chase the
+percentage with assertion-free tests that execute a line without checking behavior. (See how
+`Task.equals`/`hashCode`/the convenience `create()` overload and
+`GlobalExceptionHandler.handleInvalidTask` got covered in this repo's history — each addition
+closed a real gap, like the domain's identity semantics, not just a metric.)
+
+## Test at the layer the logic belongs to (docs/architecture.md §7)
+
+- **Domain** (`domain.model`, `domain.exception`) — plain JUnit 5, **no Spring context**. Fast,
+  isolated, tests the aggregate's own rules directly (`TaskTest`).
+- **Application** (`application.usecase`) — JUnit 5 + Mockito, `TaskRepository` mocked. No Spring
+  context here either — these classes only depend on the port interface and a `Clock`, so a
+  Spring context is pure overhead (`*ServiceTest`).
+- **Persistence** (`infrastructure.persistence`) — `@DataJpaTest` +
+  `AbstractPostgresIntegrationTest` (Testcontainers), so the Flyway migration and JPA mapping are
+  verified against a real PostgreSQL engine, not an in-memory stand-in.
+- **Web** (`infrastructure.web`) — `@WebMvcTest` + MockMvc, use cases mocked.
+
+Reach for the heaviest harness only when the layer actually needs it — a Spring context around a
+pure-Java domain test hides the class's real dependencies and slows the suite for no benefit.
+
+## How you test
+
+- **Cover the branches, not just the lines.** Every conditional, every exception path, every
+  early return needs a case. Boundary values are where bugs live — e.g. `Task`'s status
+  transition table: test each legal transition, and enough illegal ones to prove
+  `InvalidTaskStatusTransitionException` fires from every status it should.
+- **Structure for readability.** Arrange-Act-Assert, one behavior per test, descriptive method
+  names stating the expectation (`completeFailsWhenTaskIsAlreadyDone`, not `test3`). Use
+  `@Nested` classes to group by scenario the way `TaskTest` already does
+  (`Creation`/`StatusTransitions`/`Identity`). Prefer `@ParameterizedTest` for tables of inputs
+  over copy-pasted near-identical cases.
+- **Don't spend effort on trivial accessors or framework glue** — a record's generated
+  accessor or a one-line delegating method isn't where regressions hide. If a class is
+  surprisingly hard to reach the coverage floor on, that's usually a design smell (too many
+  branches in one method, a hidden dependency) worth flagging back to `task-developer` rather
+  than contorting the test to force the number up.
+- **Use `Clock.fixed(...)`, never `Clock.systemUTC()`,** in any test asserting a specific
+  timestamp — every constructor/use case that stamps time already accepts an injectable `Clock`
+  for exactly this reason.
+
+## Prove it
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw clean verify
+```
+
+`verify` runs the full suite *and* the JaCoCo coverage check (`pom.xml`) — a plain `mvn test`
+generates the report but doesn't enforce the floor. Read the HTML report under
+`target/site/jacoco/index.html` (or the CSV at `target/site/jacoco/jacoco.csv`) to see exactly
+which lines/branches remain uncovered per class, rather than guessing from the summary number.
+State the actual coverage percentage you verified — don't claim a number you didn't check.
+
+## Finishing up
+
+Only commit when asked, following the `github-commit` skill (every commit here references a
+GitHub issue) — test additions are usually `test` type, unless they accompany a
+`task-developer` feature commit already covering the same issue.

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: architecture-review
+description: Reviews a GitHub PR or the current working diff on task-manager-api against docs/architecture.md — onion-architecture layering, domain purity, the domain/entity/DTO three-model separation, SOLID, GRASP, the patterns the project commits to, package placement, and testing conventions. Use whenever the user asks to review a PR, review a diff, or check whether a change follows the architecture/clean-architecture/onion-architecture/SOLID/GRASP conventions for this repo — "review PR #4", "check this diff against our architecture", "does this class belong here", "/architecture-review". Trigger even without the word "architecture" — any request to validate a change's structure, layering, or design against this project's conventions qualifies. This is conformance/design review, not correctness or security — use /code-review or the devsecops-agent for those, alongside this one if useful.
+effort: high
+---
+
+# architecture-review
+
+Checks a diff against the architecture this project has committed to in `docs/architecture.md`,
+not just whether the code works. A change can pass every test and still put a JPA entity in the
+domain layer or let a controller decide business logic — correctness review naturally misses
+that class of problem because the code "works fine." Unlike a project with no automated
+architecture check, this repo also has a mechanical backstop
+(`OnionArchitectureTest`, ArchUnit) — run it as a cheap first pass, then do the judgment-based
+review this skill is actually for.
+
+## Workflow
+
+### 1. Run the mechanical check first
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw test -Dtest=OnionArchitectureTest
+```
+
+If this fails, the layering violation is already proven — cite the specific ArchUnit rule that
+broke and skip straight to reporting it as blocking. If it passes, that only clears layering
+*direction*; the categories below (three-model separation, SOLID, GRASP, package placement,
+pattern conformance) aren't mechanically checked and still need the read-and-judge pass.
+
+### 2. Get the diff
+
+- **PR review:** `gh pr diff <number>`.
+- **Working diff (no PR number given):** a plain `git diff` only shows tracked, unstaged
+  changes — it silently misses staged changes and, more importantly, brand-new untracked files
+  (a fresh `TaskAuditLog.java` won't appear at all, and new classes are exactly what most needs
+  reviewing). To see everything a branch actually adds:
+  - Committed work on a branch: `git diff <base>...HEAD` (three dots) where `<base>` is `main`
+    unless the user says otherwise.
+  - Staged but uncommitted: `git diff --staged`.
+  - Untracked new files: `git status --porcelain`, then read each one directly.
+
+  If it's ambiguous which of these the user means, ask rather than guessing.
+
+### 3. Read `docs/architecture.md` fresh
+
+Read the whole file before judging anything — don't rely on a remembered version from earlier
+in the conversation. It's expected to evolve as the project grows; a stale mental copy produces
+a review against rules that no longer apply. If the file is missing, say so and stop rather than
+inventing rules from general clean-architecture knowledge.
+
+### 4. Walk the diff against each section
+
+For each one, look for concrete violations in the *changed* code only — don't re-review
+unrelated existing code just because it's visible in context, and skip a section entirely if
+nothing in the diff touches it rather than forcing a comment to fill out the list.
+
+- **§2 Domain purity** — any framework import/annotation (Spring, JPA, Jackson, Lombok,
+  `jakarta.validation`) on a class in `domain/`? This is the single most common way a "quick fix"
+  quietly breaks the architecture.
+- **§1 Layering** — does `application/` reach into `infrastructure/` directly instead of through
+  a port interface it defines in `domain/`? Does a controller hold business logic instead of
+  just translating HTTP ↔ use case call?
+- **§3 Three models** — is a `TaskJpaEntity` (or any new JPA entity) leaking outside
+  `infrastructure.persistence`? Is a domain object serialized straight to the wire instead of
+  going through a `web.dto` type? Is there a new type duplicating an existing domain/entity/DTO
+  for the same concept instead of reusing it?
+- **§4 Package placement** — is every new class in the package the table in §4 says it belongs
+  in? A class that doesn't fit any row is worth flagging even if it "works," per §4's own note.
+- **§5 Patterns** — new use cases follow the one-class-per-operation shape (`UseCase<IN,OUT>`)?
+  A new outbound integration goes through a port + adapter rather than being called directly
+  from `application`? Status/workflow logic lives in the aggregate rather than in a service
+  deciding what's legal from outside it?
+- **§6 SOLID / GRASP** — SRP (a class taking on more than one reason to change), OCP (a new case
+  handled by editing an existing branch instead of extending the transition map / adding a new
+  type), DIP (`application`/`domain` doing `new SomeConcreteInfrastructureClass()` instead of
+  depending on a port).
+- **§7 Testing conventions** — is new logic tested at the layer it belongs to (plain JUnit for
+  domain/application, `@DataJpaTest`+Testcontainers for persistence, `@WebMvcTest` for web)? Is
+  there a real test at all, not just something that executes the line without asserting
+  behavior? If JaCoCo's `mvn verify` would drop below its floor because of this diff, say so.
+
+### 5. Report
+
+For each real finding: **file/class → which `docs/architecture.md` section it violates → a
+concrete suggested fix**, ranked most-important first — a domain-layer framework leak outranks a
+package-placement nit. Separate **blocking** (architecture violations, layering breaks, missing
+tests on real logic) from **non-blocking** (nits, style preferences) so the author knows what
+must change versus what's optional.
+
+If the change is clean, say so plainly and approve. Don't manufacture nitpicks to look thorough —
+an honest "this conforms, ship it" is a valid and valuable review outcome.
+
+## Notes
+
+- This is architecture + design conformance, not general code quality or security. If something
+  security-relevant turns up in passing, flag it and point to the `devsecops-agent` rather than
+  trying to do a full pass yourself.
+- `docs/architecture.md` changing (new layer, revised package table, dropped pattern) changes
+  this skill's behavior automatically next run, since the rules are read fresh each time — no
+  need to touch this file when only the architecture doc changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,131 @@
+# Architecture
+
+This is the source of truth for how task-manager-api is structured. It's read fresh by the
+`architecture-review` skill and the `architecture-reviewer` agent on every review — if this
+document changes, their behavior changes with it automatically. Keep it accurate; don't let it
+drift from what the code actually does.
+
+## 1. Layers and dependency direction
+
+Three concentric layers, dependencies only ever point **inward**:
+
+```
+infrastructure  →  application  →  domain
+```
+
+- **`domain`** (`com.taskmanager.api.domain`) — the `Task` aggregate, `TaskStatus`, domain
+  exceptions, and the `TaskRepository` port interface. Nothing outside this package may be
+  imported here.
+- **`application`** (`com.taskmanager.api.application`) — one use case per operation
+  (`CreateTaskUseCase`/`CreateTaskService`, etc.), plus command records. Depends only on
+  `domain`.
+- **`infrastructure`** (`com.taskmanager.api.infrastructure`) — everything that talks to the
+  outside world: `web` (controllers, DTOs, exception handling), `persistence` (JPA adapter),
+  `config`. Depends on both inner layers; nothing may depend on it.
+
+This is mechanically enforced, not just documented: see
+`src/test/java/com/taskmanager/api/architecture/OnionArchitectureTest.java` (ArchUnit). A
+change that violates layering fails the build, not just this review.
+
+## 2. Domain purity (§2)
+
+`domain/` is plain Java with **zero framework dependencies** — no Spring, no JPA/Hibernate, no
+Jackson, no Lombok. `Task` hand-writes its own constructors, accessors, `equals`/`hashCode`.
+The business rules must compile and behave the same even if every framework were stripped from
+the build. This is what lets domain tests (`TaskTest`) run in milliseconds with no Spring
+context.
+
+Framework annotations and DI markers belong in `application` and `infrastructure` only.
+`@Service`/`@Component` on application-layer classes is accepted as a pragmatic exception
+(it's a DI marker, not a functional dependency) — but nothing from `org.springframework..`,
+`jakarta.persistence..`, or `jakarta.validation..` may appear in `domain/`. Enforced by the
+`domain_is_free_of_framework_dependencies` ArchUnit rule.
+
+## 3. The three models, never mixed (§3)
+
+A `Task` (domain aggregate), a `TaskJpaEntity` (persistence record), and a `TaskResponse`
+(web DTO) are three distinct types for the same concept, deliberately not unified:
+
+- **`Task`** (`domain.model`) — immutable, enforces its own invariants (title length, valid
+  status transitions), the only place business rules live.
+- **`TaskJpaEntity`** (`infrastructure.persistence.entity`) — mutable, JPA-annotated, exists
+  purely to satisfy Hibernate. Never leaves the `persistence` package as itself.
+- **`TaskResponse`** / request DTOs (`infrastructure.web.dto`) — the wire shape, decoupled from
+  both of the above so the API contract can evolve independently of the schema or the domain
+  model.
+
+Translation happens at explicit boundaries only: `TaskPersistenceMapper` (entity ↔ domain) and
+`TaskWebMapper` (domain → response). A controller must never return a `TaskJpaEntity`, and a
+JPA entity must never appear in `domain/` or be serialized directly.
+
+## 4. Package placement
+
+| What | Package |
+|---|---|
+| Aggregate, value objects, domain exceptions | `domain.model`, `domain.exception` |
+| Repository port (interface only) | `domain.repository` |
+| Use case interface + implementation | `application.usecase` |
+| Use case input records | `application.command` |
+| REST controller | `infrastructure.web.controller` |
+| Request/response DTOs, error shape | `infrastructure.web.dto` |
+| `@RestControllerAdvice` exception mapping | `infrastructure.web.exception` |
+| Domain ↔ DTO translation | `infrastructure.web.mapper` |
+| JPA entity | `infrastructure.persistence.entity` |
+| Spring Data repository interface | `infrastructure.persistence` (package-private) |
+| Repository port implementation (adapter) | `infrastructure.persistence` |
+| Entity ↔ domain translation | `infrastructure.persistence.mapper` |
+| Spring `@Configuration` beans | `infrastructure.config` |
+
+A new class that doesn't fit one of these rows is a signal to reconsider the design, not to
+invent a new package ad hoc — flag it for discussion rather than guessing.
+
+## 5. Patterns in use
+
+- **Repository (port/adapter)** — `domain.repository.TaskRepository` is the port;
+  `infrastructure.persistence.TaskRepositoryAdapter` is the only adapter. Application code
+  depends on the interface, never on Spring Data or JPA directly (Dependency Inversion).
+- **Adapter** — `TaskRepositoryAdapter` adapts Spring Data JPA to the domain's port; the same
+  shape would apply to any future outbound integration (an external API, a message queue).
+- **Command pattern for use cases** — `UseCase<IN, OUT>` with one implementation class per
+  operation (`CreateTaskService`, `DeleteTaskService`, ...). Each has a single reason to
+  change (SRP) and is trivially testable in isolation with a mocked `TaskRepository`.
+- **Immutable aggregate with self-validating transitions** — `Task.start()`/`complete()`/
+  `reopen()`/`updateDetails()` each return a *new* `Task` after checking the move is legal,
+  rather than mutating shared state or letting a service class decide what transitions are
+  valid. The state machine lives in the aggregate itself (Information Expert, from GRASP).
+- **Explicit mapper, not a mapping library** — `TaskPersistenceMapper` and `TaskWebMapper` are
+  plain static methods, not MapStruct/ModelMapper. For three fields' worth of aggregates this
+  is more debuggable than it is boilerplate; revisit if the domain grows enough that manual
+  mapping becomes the actual maintenance burden.
+
+## 6. SOLID / GRASP, applied
+
+- **SRP** — one use case class per operation; the controller only translates HTTP ↔ use case
+  call, `GlobalExceptionHandler` only translates exception ↔ HTTP status.
+- **OCP** — a new status transition is a new branch in `Task`'s `ALLOWED_TRANSITIONS` map plus
+  a new `TaskStatusAction`, not a rewrite of existing transition methods.
+- **DIP** — `application` depends on `domain.repository.TaskRepository` (an interface it owns),
+  never on `infrastructure.persistence` directly; Spring wires the concrete adapter in at
+  runtime.
+- **Low coupling / Protected Variations** — the JPA schema (`TaskJpaEntity`, Flyway migrations)
+  can change without touching `domain` or `application`, and vice versa, because the mapper is
+  the only thing that knows both shapes.
+
+## 7. Testing conventions
+
+- **Domain** — plain JUnit 5, no Spring context (`TaskTest`). Milliseconds, no I/O.
+- **Application** — JUnit 5 + Mockito, `TaskRepository` mocked (`*ServiceTest`). No Spring
+  context.
+- **Persistence** — `@DataJpaTest` + Testcontainers against real PostgreSQL
+  (`TaskRepositoryAdapterTest`), so the Flyway migration and JPA mapping are verified against
+  the real database engine, not an in-memory stand-in.
+- **Web** — `@WebMvcTest` + MockMvc, use cases mocked (`TaskControllerTest`).
+- **Architecture** — ArchUnit (`OnionArchitectureTest`), enforcing everything in §1–§2
+  mechanically rather than relying on review alone to catch a layering violation.
+- **Coverage** — enforced via JaCoCo (`pom.xml`); see the badge/threshold configured there for
+  the current target. Coverage is a means, not the goal: a test that executes a line without
+  asserting real behavior doesn't count, regardless of what the percentage says.
+
+New code should follow the same TDD flow this codebase was built with: write the failing test
+first, at the layer the logic actually belongs to (per §1), then implement the minimum to pass
+it.

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
     <properties>
         <java.version>21</java.version>
         <archunit.version>1.4.2</archunit.version>
+        <jacoco.version>0.8.15</jacoco.version>
+        <!-- Line/branch coverage floor enforced by `mvn verify`. The existing TDD suite already
+             exercises nearly everything; raise this as coverage on new code grows, don't lower
+             it to make a red build pass. -->
+        <jacoco.coverage.minimum>0.85</jacoco.coverage.minimum>
     </properties>
 
     <dependencies>
@@ -102,6 +107,60 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <!-- Instrument classes for coverage collection. -->
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- Human-readable HTML/XML report under target/site/jacoco after `mvn test`. -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <!-- Fails `mvn verify` if coverage drops below the floor. -->
+                    <execution>
+                        <id>check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <!-- Spring Boot bootstrap: no meaningful branches to cover. -->
+                                <exclude>com/taskmanager/api/TaskManagerApiApplication.class</exclude>
+                            </excludes>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.coverage.minimum}</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.coverage.minimum}</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/taskmanager/api/domain/model/TaskTest.java
+++ b/src/test/java/com/taskmanager/api/domain/model/TaskTest.java
@@ -66,6 +66,54 @@ class TaskTest {
                     .isInstanceOf(InvalidTaskException.class)
                     .hasMessageContaining("2000");
         }
+
+        @Test
+        void systemClockOverloadStampsCurrentTime() {
+            Instant before = Instant.now();
+
+            Task task = Task.create("Title", null, null);
+
+            assertThat(task.createdAt()).isBetween(before, Instant.now());
+            assertThat(task.updatedAt()).isEqualTo(task.createdAt());
+        }
+    }
+
+    @Nested
+    class Identity {
+
+        @Test
+        void tasksWithTheSameIdAreEqualEvenIfOtherFieldsDiffer() {
+            Task original = Task.create("Title", null, null, FIXED_CLOCK);
+            Task laterVersion = original.updateDetails("Different title", "desc", null, FIXED_CLOCK);
+
+            assertThat(laterVersion).isEqualTo(original);
+            assertThat(laterVersion).hasSameHashCodeAs(original);
+        }
+
+        @Test
+        void tasksWithDifferentIdsAreNeverEqual() {
+            Task first = Task.create("Same title", null, null, FIXED_CLOCK);
+            Task second = Task.create("Same title", null, null, FIXED_CLOCK);
+
+            assertThat(first).isNotEqualTo(second);
+        }
+
+        @Test
+        void aTaskIsNotEqualToSomeOtherType() {
+            Task task = Task.create("Title", null, null, FIXED_CLOCK);
+
+            assertThat(task).isNotEqualTo("not a task");
+        }
+
+        @Test
+        void toStringIncludesIdTitleAndStatus() {
+            Task task = Task.create("Write docs", null, null, FIXED_CLOCK);
+
+            assertThat(task.toString())
+                    .contains(task.id().toString())
+                    .contains("Write docs")
+                    .contains("TODO");
+        }
     }
 
     @Nested

--- a/src/test/java/com/taskmanager/api/infrastructure/web/TaskControllerTest.java
+++ b/src/test/java/com/taskmanager/api/infrastructure/web/TaskControllerTest.java
@@ -11,6 +11,7 @@ import com.taskmanager.api.application.usecase.DeleteTaskUseCase;
 import com.taskmanager.api.application.usecase.GetTaskUseCase;
 import com.taskmanager.api.application.usecase.ListTasksUseCase;
 import com.taskmanager.api.application.usecase.UpdateTaskUseCase;
+import com.taskmanager.api.domain.exception.InvalidTaskException;
 import com.taskmanager.api.domain.exception.InvalidTaskStatusTransitionException;
 import com.taskmanager.api.domain.exception.TaskNotFoundException;
 import com.taskmanager.api.domain.model.Task;
@@ -97,6 +98,22 @@ class TaskControllerTest {
                         .content(objectMapper.writeValueAsString(new CreateTaskRequest("  ", null, null))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void returns400WhenDomainRejectsAnInvalidTaskOutsideBeanValidation() throws Exception {
+        // A domain invariant can differ from the DTO's own @Size/@NotBlank bounds, so
+        // InvalidTaskException can reach the controller without MethodArgumentNotValidException
+        // ever being raised - this exercises that path specifically, not the @Valid one above.
+        when(createTaskUseCase.execute(any(CreateTaskCommand.class)))
+                .thenThrow(new InvalidTaskException("Task title must not be blank"));
+
+        mockMvc.perform(post("/api/tasks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTaskRequest("Valid title", null, null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Task title must not be blank"));
     }
 
     @Test


### PR DESCRIPTION
## What
Adds architecture rigor tooling on top of the core API: a canonical architecture document, an enforced JaCoCo coverage gate, and the Claude Code skills/agents that read and act on both.

## Related issues
Closes #9
Closes #10
Closes #11
Closes #12
Closes #8

## Changes
- `docs/architecture.md`: numbered-section canonical architecture reference (layering & dependency direction, domain purity, the three-model separation, package placement, patterns in use, SOLID/GRASP application, testing conventions) — the source of truth the architecture-review skill and architecture-reviewer agent read fresh on every invocation
- `pom.xml`: `jacoco-maven-plugin` bound to `verify` with an 85% line/branch coverage floor (`TaskManagerApiApplication` excluded as untestable bootstrap)
- Closed 3 real coverage gaps surfaced by the gate rather than lowering the bar: `Task.equals`/`hashCode` and the 3-arg `create()` overload gained tests, and `GlobalExceptionHandler`'s domain-exception-to-400 path (distinct from the bean-validation-to-400 path) is now exercised
- `.claude/skills/architecture-review/SKILL.md` + `.claude/agents/architecture-reviewer.md`: read-only skill/agent pair reviewing a diff or PR against `docs/architecture.md` plus general code quality, running `OnionArchitectureTest` as a mechanical first pass before judgment-based review
- `.claude/agents/task-developer.md`: implements new features/use cases following `docs/architecture.md` (TDD-aware, leaves exhaustive edge-case coverage to the tester)
- `.claude/agents/unit-tester.md`: writes/strengthens JUnit 5 tests and drives the JaCoCo floor, matching the per-layer test style already established

## Testing
`./mvnw clean test` passes (57/57). The new JaCoCo gate is bound to `verify`, not `test`, and enforces an 85% line/branch floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
