### PR TITLE
feat(web): implement REST web layer with controller and error handling

### DIFF
--- a/src/main/java/com/taskmanager/api/infrastructure/web/controller/TaskController.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/web/controller/TaskController.java
@@ -1,0 +1,102 @@
+package com.taskmanager.api.infrastructure.web.controller;
+
+import com.taskmanager.api.application.command.ChangeTaskStatusCommand;
+import com.taskmanager.api.application.command.CreateTaskCommand;
+import com.taskmanager.api.application.command.UpdateTaskCommand;
+import com.taskmanager.api.application.usecase.ChangeTaskStatusUseCase;
+import com.taskmanager.api.application.usecase.CreateTaskUseCase;
+import com.taskmanager.api.application.usecase.DeleteTaskUseCase;
+import com.taskmanager.api.application.usecase.GetTaskUseCase;
+import com.taskmanager.api.application.usecase.ListTasksUseCase;
+import com.taskmanager.api.application.usecase.UpdateTaskUseCase;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.infrastructure.web.dto.ChangeTaskStatusRequest;
+import com.taskmanager.api.infrastructure.web.dto.CreateTaskRequest;
+import com.taskmanager.api.infrastructure.web.dto.TaskResponse;
+import com.taskmanager.api.infrastructure.web.dto.UpdateTaskRequest;
+import com.taskmanager.api.infrastructure.web.mapper.TaskWebMapper;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Inbound HTTP adapter for the Task use cases. Depends only on the application layer's
+ * use case interfaces - it has no knowledge of how tasks are persisted.
+ */
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+    private final CreateTaskUseCase createTaskUseCase;
+    private final GetTaskUseCase getTaskUseCase;
+    private final ListTasksUseCase listTasksUseCase;
+    private final UpdateTaskUseCase updateTaskUseCase;
+    private final DeleteTaskUseCase deleteTaskUseCase;
+    private final ChangeTaskStatusUseCase changeTaskStatusUseCase;
+
+    public TaskController(CreateTaskUseCase createTaskUseCase,
+                           GetTaskUseCase getTaskUseCase,
+                           ListTasksUseCase listTasksUseCase,
+                           UpdateTaskUseCase updateTaskUseCase,
+                           DeleteTaskUseCase deleteTaskUseCase,
+                           ChangeTaskStatusUseCase changeTaskStatusUseCase) {
+        this.createTaskUseCase = createTaskUseCase;
+        this.getTaskUseCase = getTaskUseCase;
+        this.listTasksUseCase = listTasksUseCase;
+        this.updateTaskUseCase = updateTaskUseCase;
+        this.deleteTaskUseCase = deleteTaskUseCase;
+        this.changeTaskStatusUseCase = changeTaskStatusUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<TaskResponse> create(@Valid @RequestBody CreateTaskRequest request) {
+        Task task = createTaskUseCase.execute(
+                new CreateTaskCommand(request.title(), request.description(), request.dueDate()));
+
+        return ResponseEntity.created(URI.create("/api/tasks/" + task.id()))
+                .body(TaskWebMapper.toResponse(task));
+    }
+
+    @GetMapping("/{id}")
+    public TaskResponse getById(@PathVariable UUID id) {
+        return TaskWebMapper.toResponse(getTaskUseCase.execute(id));
+    }
+
+    @GetMapping
+    public List<TaskResponse> list() {
+        return listTasksUseCase.execute().stream()
+                .map(TaskWebMapper::toResponse)
+                .toList();
+    }
+
+    @PutMapping("/{id}")
+    public TaskResponse update(@PathVariable UUID id, @Valid @RequestBody UpdateTaskRequest request) {
+        Task task = updateTaskUseCase.execute(
+                new UpdateTaskCommand(id, request.title(), request.description(), request.dueDate()));
+        return TaskWebMapper.toResponse(task);
+    }
+
+    @PatchMapping("/{id}/status")
+    public TaskResponse changeStatus(@PathVariable UUID id, @Valid @RequestBody ChangeTaskStatusRequest request) {
+        Task task = changeTaskStatusUseCase.execute(new ChangeTaskStatusCommand(id, request.action()));
+        return TaskWebMapper.toResponse(task);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        deleteTaskUseCase.execute(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/web/dto/ChangeTaskStatusRequest.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/web/dto/ChangeTaskStatusRequest.java
@@ -1,0 +1,11 @@
+package com.taskmanager.api.infrastructure.web.dto;
+
+import com.taskmanager.api.application.command.TaskStatusAction;
+import jakarta.validation.constraints.NotNull;
+
+public record ChangeTaskStatusRequest(
+
+        @NotNull(message = "action must not be null")
+        TaskStatusAction action
+) {
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/web/dto/CreateTaskRequest.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/web/dto/CreateTaskRequest.java
@@ -1,0 +1,19 @@
+package com.taskmanager.api.infrastructure.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record CreateTaskRequest(
+
+        @NotBlank(message = "title must not be blank")
+        @Size(max = 200, message = "title must not exceed 200 characters")
+        String title,
+
+        @Size(max = 2000, message = "description must not exceed 2000 characters")
+        String description,
+
+        LocalDate dueDate
+) {
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/web/dto/ErrorResponse.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/web/dto/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.taskmanager.api.infrastructure.web.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ErrorResponse(
+        Instant timestamp,
+        int status,
+        String error,
+        String message,
+        String path,
+        List<String> details
+) {
+
+    public ErrorResponse(int status, String error, String message, String path) {
+        this(Instant.now(), status, error, message, path, List.of());
+    }
+
+    public ErrorResponse(int status, String error, String message, String path, List<String> details) {
+        this(Instant.now(), status, error, message, path, details);
+    }
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/web/dto/TaskResponse.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/web/dto/TaskResponse.java
@@ -1,0 +1,16 @@
+package com.taskmanager.api.infrastructure.web.dto;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record TaskResponse(
+        UUID id,
+        String title,
+        String description,
+        String status,
+        LocalDate dueDate,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/web/dto/UpdateTaskRequest.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/web/dto/UpdateTaskRequest.java
@@ -1,0 +1,19 @@
+package com.taskmanager.api.infrastructure.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record UpdateTaskRequest(
+
+        @NotBlank(message = "title must not be blank")
+        @Size(max = 200, message = "title must not exceed 200 characters")
+        String title,
+
+        @Size(max = 2000, message = "description must not exceed 2000 characters")
+        String description,
+
+        LocalDate dueDate
+) {
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+package com.taskmanager.api.infrastructure.web.exception;
+
+import com.taskmanager.api.domain.exception.InvalidTaskException;
+import com.taskmanager.api.domain.exception.InvalidTaskStatusTransitionException;
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.infrastructure.web.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.List;
+
+/**
+ * Translates domain/application exceptions into HTTP responses. This is the single place
+ * where "what went wrong internally" is turned into "what the client sees" - controllers
+ * stay free of try/catch blocks.
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(TaskNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(TaskNotFoundException ex, WebRequest request) {
+        return build(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(InvalidTaskException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidTask(InvalidTaskException ex, WebRequest request) {
+        return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(InvalidTaskStatusTransitionException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidTransition(InvalidTaskStatusTransitionException ex, WebRequest request) {
+        return build(HttpStatus.CONFLICT, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex, WebRequest request) {
+        List<String> details = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .toList();
+
+        ErrorResponse body = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "Validation failed",
+                path(request),
+                details
+        );
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    private ResponseEntity<ErrorResponse> build(HttpStatus status, String message, WebRequest request) {
+        ErrorResponse body = new ErrorResponse(status.value(), status.getReasonPhrase(), message, path(request));
+        return ResponseEntity.status(status).body(body);
+    }
+
+    private String path(WebRequest request) {
+        return request.getDescription(false).replace("uri=", "");
+    }
+}

--- a/src/main/java/com/taskmanager/api/infrastructure/web/mapper/TaskWebMapper.java
+++ b/src/main/java/com/taskmanager/api/infrastructure/web/mapper/TaskWebMapper.java
@@ -1,0 +1,22 @@
+package com.taskmanager.api.infrastructure.web.mapper;
+
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.infrastructure.web.dto.TaskResponse;
+
+public final class TaskWebMapper {
+
+    private TaskWebMapper() {
+    }
+
+    public static TaskResponse toResponse(Task task) {
+        return new TaskResponse(
+                task.id(),
+                task.title(),
+                task.description(),
+                task.status().name(),
+                task.dueDate(),
+                task.createdAt(),
+                task.updatedAt()
+        );
+    }
+}

--- a/src/test/java/com/taskmanager/api/infrastructure/web/TaskControllerTest.java
+++ b/src/test/java/com/taskmanager/api/infrastructure/web/TaskControllerTest.java
@@ -1,0 +1,197 @@
+package com.taskmanager.api.infrastructure.web;
+
+import tools.jackson.databind.ObjectMapper;
+import com.taskmanager.api.application.command.ChangeTaskStatusCommand;
+import com.taskmanager.api.application.command.CreateTaskCommand;
+import com.taskmanager.api.application.command.TaskStatusAction;
+import com.taskmanager.api.application.command.UpdateTaskCommand;
+import com.taskmanager.api.application.usecase.ChangeTaskStatusUseCase;
+import com.taskmanager.api.application.usecase.CreateTaskUseCase;
+import com.taskmanager.api.application.usecase.DeleteTaskUseCase;
+import com.taskmanager.api.application.usecase.GetTaskUseCase;
+import com.taskmanager.api.application.usecase.ListTasksUseCase;
+import com.taskmanager.api.application.usecase.UpdateTaskUseCase;
+import com.taskmanager.api.domain.exception.InvalidTaskStatusTransitionException;
+import com.taskmanager.api.domain.exception.TaskNotFoundException;
+import com.taskmanager.api.domain.model.Task;
+import com.taskmanager.api.domain.model.TaskStatus;
+import com.taskmanager.api.infrastructure.web.controller.TaskController;
+import com.taskmanager.api.infrastructure.web.dto.ChangeTaskStatusRequest;
+import com.taskmanager.api.infrastructure.web.dto.CreateTaskRequest;
+import com.taskmanager.api.infrastructure.web.dto.UpdateTaskRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TaskController.class)
+class TaskControllerTest {
+
+    private static final Clock FIXED_CLOCK = Clock.systemUTC();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CreateTaskUseCase createTaskUseCase;
+
+    @MockitoBean
+    private GetTaskUseCase getTaskUseCase;
+
+    @MockitoBean
+    private ListTasksUseCase listTasksUseCase;
+
+    @MockitoBean
+    private UpdateTaskUseCase updateTaskUseCase;
+
+    @MockitoBean
+    private DeleteTaskUseCase deleteTaskUseCase;
+
+    @MockitoBean
+    private ChangeTaskStatusUseCase changeTaskStatusUseCase;
+
+    @Test
+    void createsATaskAndReturns201WithLocationHeader() throws Exception {
+        Task task = Task.create("Write tests", "Follow TDD", LocalDate.of(2026, 9, 1), FIXED_CLOCK);
+        when(createTaskUseCase.execute(any(CreateTaskCommand.class))).thenReturn(task);
+
+        mockMvc.perform(post("/api/tasks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CreateTaskRequest("Write tests", "Follow TDD", LocalDate.of(2026, 9, 1)))))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/tasks/" + task.id()))
+                .andExpect(jsonPath("$.id").value(task.id().toString()))
+                .andExpect(jsonPath("$.title").value("Write tests"))
+                .andExpect(jsonPath("$.status").value("TODO"));
+    }
+
+    @Test
+    void rejectsCreateWithBlankTitle() throws Exception {
+        mockMvc.perform(post("/api/tasks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTaskRequest("  ", null, null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void returnsATaskById() throws Exception {
+        Task task = Task.create("Task", null, null, FIXED_CLOCK);
+        when(getTaskUseCase.execute(task.id())).thenReturn(task);
+
+        mockMvc.perform(get("/api/tasks/{id}", task.id()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(task.id().toString()));
+    }
+
+    @Test
+    void returns404WhenTaskNotFound() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(getTaskUseCase.execute(id)).thenThrow(new TaskNotFoundException(id));
+
+        mockMvc.perform(get("/api/tasks/{id}", id))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    void listsAllTasks() throws Exception {
+        Task task = Task.create("Task", null, null, FIXED_CLOCK);
+        when(listTasksUseCase.execute()).thenReturn(List.of(task));
+
+        mockMvc.perform(get("/api/tasks"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(task.id().toString()));
+    }
+
+    @Test
+    void updatesATask() throws Exception {
+        Task task = Task.create("Task", null, null, FIXED_CLOCK)
+                .updateDetails("New title", "New desc", null, FIXED_CLOCK);
+        when(updateTaskUseCase.execute(any(UpdateTaskCommand.class))).thenReturn(task);
+
+        mockMvc.perform(put("/api/tasks/{id}", task.id())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new UpdateTaskRequest("New title", "New desc", null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("New title"));
+    }
+
+    @Test
+    void changesTaskStatus() throws Exception {
+        Task task = Task.create("Task", null, null, FIXED_CLOCK).start(FIXED_CLOCK);
+        when(changeTaskStatusUseCase.execute(any(ChangeTaskStatusCommand.class))).thenReturn(task);
+
+        mockMvc.perform(patch("/api/tasks/{id}/status", task.id())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ChangeTaskStatusRequest(TaskStatusAction.START))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("IN_PROGRESS"));
+    }
+
+    @Test
+    void returns409OnInvalidStatusTransition() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(changeTaskStatusUseCase.execute(any(ChangeTaskStatusCommand.class)))
+                .thenThrow(new InvalidTaskStatusTransitionException(TaskStatus.DONE, TaskStatus.IN_PROGRESS));
+
+        mockMvc.perform(patch("/api/tasks/{id}/status", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ChangeTaskStatusRequest(TaskStatusAction.START))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void deletesATaskAndReturns204() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/tasks/{id}", id))
+                .andExpect(status().isNoContent());
+
+        verify(deleteTaskUseCase).execute(eq(id));
+    }
+
+    @Test
+    void returns404WhenDeletingMissingTask() throws Exception {
+        UUID id = UUID.randomUUID();
+        org.mockito.Mockito.doThrow(new TaskNotFoundException(id)).when(deleteTaskUseCase).execute(id);
+
+        mockMvc.perform(delete("/api/tasks/{id}", id))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void content_type_is_json_for_error_responses() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(getTaskUseCase.execute(id)).thenThrow(new TaskNotFoundException(id));
+
+        mockMvc.perform(get("/api/tasks/{id}", id))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+}


### PR DESCRIPTION
## What
Implements the REST web layer: controller, DTOs, and centralized error handling.

## Related issues
Closes #6

## Changes
- `TaskController` (`POST/GET/PUT/DELETE /api/tasks`, `PATCH /api/tasks/{id}/status`)
- Request/response DTOs with bean validation, `TaskWebMapper`
- `GlobalExceptionHandler` mapping domain exceptions to HTTP status (404/400/409)

## Testing
`TaskControllerTest` (`@WebMvcTest` + MockMvc), use cases mocked.

**Note:** supersedes PR #24 (see #29 for context on the retarget-to-main fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)