### PR TITLE
feat: add GitHub workflow tooling (issue-linked commits, issues, PRs, triage)

### DIFF
--- a/.claude/agents/issue-triager.md
+++ b/.claude/agents/issue-triager.md
@@ -1,0 +1,31 @@
+---
+name: issue-triager
+description: Reviews open GitHub issues on task-manager-api and organizes them - applying type/area labels, flagging duplicates or stale/unclear issues, and producing a short status summary. Use when the user wants the issue tracker triaged or cleaned up as a standalone task, e.g. "triage the backlog" or "what's the state of open issues".
+tools: Bash, Read, Grep, Glob
+model: sonnet
+effort: high
+---
+
+You triage the GitHub issue tracker for task-manager-api. Follow the `github-issues` project
+skill for the label taxonomy and conventions - read `.claude/skills/github-issues/SKILL.md`
+first if it's not already in context.
+
+Your job:
+
+1. `gh issue list --state open` to see everything open, then read each one
+   (`gh issue view <n>`) that doesn't already have both a type and area label.
+2. For issues with a clear type (`bug`/`enhancement`/`refactor`/`docs`/`testing`) and area
+   (`domain`/`application`/`infrastructure`/`web`), apply the labels directly with
+   `gh issue edit`.
+3. For anything ambiguous - vague description, likely duplicate, can't tell if it's still
+   relevant - do not guess or close it. Note it in your final report instead; labeling
+   something wrong is worse than leaving it unlabeled, since it actively misleads whoever
+   filters by that label later.
+4. Check for obvious duplicates (similar titles/descriptions) and flag the pair rather than
+   closing either - closing is a judgment call for the user, not something to automate.
+5. Finish with a short summary: how many issues you labeled, how many you flagged for human
+   judgment and why, and anything that looks stale (no activity, likely already fixed by
+   recent work on `main`).
+
+You're not authorized to close issues, change milestones, or delete labels - only to add
+type/area labels to issues where they're unambiguous, and to report on everything else.

--- a/.claude/agents/pr-manager.md
+++ b/.claude/agents/pr-manager.md
@@ -1,0 +1,41 @@
+---
+name: pr-manager
+description: Ships a finished branch in task-manager-api as a pull request, or refreshes an already-open one - verifies the build is green, pushes the branch, writes a description grounded in the real commits (including their issue references), and runs gh pr create/edit. Use when the user wants to hand off "open a PR for this branch", "ship this", or "update the PR description" as a self-contained task, rather than doing it inline in the main conversation.
+tools: Bash, Read, Grep, Glob
+model: sonnet
+effort: high
+---
+
+You turn a finished branch in the task-manager-api repo into a pull request, or keep an existing
+one's description honest as more commits land. Follow the `github-pr` project skill for the
+exact format and commands - read `.claude/skills/github-pr/SKILL.md` first if it's not already
+in context.
+
+Your job, in order:
+
+1. Confirm you're on a feature branch, not `main`.
+2. Run `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw test`. If it fails, stop and report the
+   failure back rather than trying to fix the code yourself - that's a different task with
+   different risk, and silently patching things to make a PR look green would hide the real
+   state of the branch from whoever asked for it.
+3. Find the base branch (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`) and
+   read the real diff/commit log against it - that's the source of truth for the description,
+   not the conversation that produced the commits.
+4. Scan the commits for their `closes|fixes|refs #<N>` issue references (every commit in this
+   repo has one, per the `github-commit` skill) and carry them into the PR body's "Related
+   issues" section verbatim.
+5. Write the PR description using the skill's template (What / Related issues / Changes /
+   Testing), including the required footer.
+6. **New PR:** push the branch and run `gh pr create`. **Existing open PR for this branch:**
+   re-derive the description from the current state and run `gh pr edit <number>` instead -
+   check with `gh pr view --json number -q .number` first.
+7. Report back the PR URL and a short summary of what you opened or updated.
+
+Opening or editing a PR is outward-facing - if anything about the branch state is surprising
+(unexpected files changed, a merge conflict with the base branch, no commits at all), stop and
+report it instead of pushing ahead. You are not authorized to force-push or rewrite history.
+
+**You never merge, and you never imply the PR is ready to merge as if that were your call.** A
+human reviews and approves every merge in this repo. Your job ends at opening/updating the PR
+and reporting its URL back - if asked to merge one, say that's a step for the user (or a human
+reviewer) to take themselves.

--- a/.claude/skills/github-commit/SKILL.md
+++ b/.claude/skills/github-commit/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: github-commit
+description: Write commit messages and structure commits for the task-manager-api repo (Java 21 / Spring Boot, TDD, onion architecture) — every commit must reference a GitHub issue. Use this whenever the user asks to commit changes, wants a commit message drafted, says "commit this", finishes implementing something and it's time to check it in, or is about to run `git commit` for any change in this repo, however small.
+---
+
+# Committing in task-manager-api
+
+## Before committing
+
+Run the test suite and make sure it's green:
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw test
+```
+
+(The default `java` on this machine isn't 21, hence the explicit `JAVA_HOME`.) A commit that
+introduces a broken build defeats the point of the TDD/CI setup this project is built around -
+don't commit red. If the user explicitly wants to checkpoint broken work anyway, that's their
+call, but say so out loud first rather than silently committing a failing build.
+
+Also check what branch you're on (`git branch --show-current`). Beyond the very first
+scaffolding commits, work should happen on a feature branch, not directly on `main` - create
+one (`git checkout -b <type>/<short-description>`) before committing if you're still on `main`.
+
+## Message format
+
+Every commit references a GitHub issue - that's what makes `git log` traceable back to the work
+that motivated it, and it's non-negotiable here even for small changes:
+
+```
+<type>(<scope>): <subject>, <ref-keyword> #<issue_number>
+```
+
+- **type**: `feat`, `fix`, `test`, `refactor`, `docs`, `chore`, `build`, `ci`.
+- **scope** (optional but useful here): the architecture layer or feature touched - `domain`,
+  `application`, `infrastructure`, `web`, `persistence` - since this repo is organized around
+  onion architecture and the scope makes it obvious at a glance which layer changed.
+- **subject**: imperative mood, no trailing period - "add due-date validation to Task", not
+  "added" or "adds".
+- **ref-keyword**: `closes` | `fixes` | `refs`.
+  - `closes`/`fixes` - this commit is the piece of work that satisfies the issue (GitHub
+    auto-closes it when merged to `main`). Interchangeable.
+  - `refs` - related to the issue but doesn't resolve it (partial progress, or one of several
+    commits contributing to the same issue).
+
+A commit can reference more than one issue - most often when it finishes a sub-issue and thereby
+also completes its parent: repeat the keyword per issue, comma-separated
+(`… , closes #22, closes #19`), and keywords can mix (`… , closes #22, refs #19`) when the
+commit resolves one but only advances the other.
+
+**Finding the issue number:**
+- If the user names one, use it.
+- Otherwise look for a matching open issue: `gh issue list`. If more than one plausibly matches,
+  ask rather than guessing.
+- If genuinely no issue exists yet, stop and ask whether to file one first (the `github-issues`
+  skill covers that) - never fabricate a number or silently drop the reference; that defeats the
+  whole point of the format.
+
+**Examples:**
+```
+feat(domain): add reopen transition to Task aggregate, closes #14
+test(application): cover ChangeTaskStatusService invalid-transition case, refs #14
+fix(persistence): map due_date column as nullable, fixes #21
+refactor(web): extract TaskWebMapper from controller, refs #9
+chore: bump archunit to 1.4.2, closes #25
+feat(domain): add Task priority field, closes #30, closes #28
+```
+(the last one finishes sub-issue #28 and thereby its parent #30)
+
+## TDD history: squash or preserve?
+
+When a change was built red-green-refactor, it's usually fine (and more useful to future
+readers) to land it as one commit that includes the test and the implementation together -
+nobody wants to `git blame` back to a commit that's a test with no passing code. Only split
+into separate `test:` then `feat:` commits if the user explicitly wants the red/green steps
+preserved in history (e.g. as a teaching artifact, or because they asked for it).
+
+## Trailer
+
+Every commit made by Claude in this repo ends with:
+
+```
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+This is a repo convention, not just a session default - keep it even if a future session's
+system prompt doesn't mention it, so the git history stays consistent regardless of which
+tool or session made the commit.
+
+## Scope of what gets committed
+
+Check `git status` before staging - stage exactly the files the change touches
+(`git add <files>`), not a blanket `git add -A`, so unrelated in-progress work doesn't get
+swept in. Build output (`target/`), `.env`, and IDE files are already covered by
+`.gitignore`; if something generated shows up as untracked, that's a sign the ignore rules
+need updating, not that it should be committed.

--- a/.claude/skills/github-issues/SKILL.md
+++ b/.claude/skills/github-issues/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: github-issues
+description: Create and triage GitHub issues for the task-manager-api repo via the gh CLI, including real linked GitHub sub-issues for work big enough to split up. Use whenever the user asks to file a bug, request a feature, open an issue, wants to see what's open, or asks to triage/organize/clean up the issue tracker. Every commit and PR in this repo references an issue, so this is also the first step before any implementation work that doesn't already have one.
+---
+
+# Issues in task-manager-api
+
+## Creating an issue
+
+### 1. Gather the content
+
+- **Title** - short imperative phrase, e.g. "Add due-date filter to task list endpoint".
+- **Description** - a paragraph explaining the issue.
+- **Sub-issues** - titles for discrete pieces of follow-up work, if the issue is big enough to
+  warrant breaking up (e.g. "implement the use case", "add the controller endpoint", "cover it
+  in ArchUnit if it introduces a new package"). Not every issue needs these - small, single-step
+  issues can have an empty list.
+- **Acceptance criteria** - a checklist of concrete, verifiable conditions. Prefer "`GET
+  /api/tasks?dueBefore=` returns 400 for an unparsable date" over "handle bad input" - something
+  you could literally check a box on after doing the work.
+
+Ask the user directly for anything unclear rather than guessing at scope.
+
+### 2. Format the body
+
+```markdown
+## Description
+What the problem or request is, referencing the relevant architecture layer if useful.
+
+## Sub-issues
+<title of sub-issue 1>
+<title of sub-issue 2>
+
+## Acceptance Criteria
+- [ ] Concrete, checkable condition
+- [ ] Another one
+
+## Related
+Closes #123 / relates to #456, if applicable.
+```
+
+Omit the "Sub-issues" section entirely if there are none - don't leave it as an empty header.
+Each sub-issue gets its own short body (a sentence or two is enough).
+
+### 3. Preview and get explicit confirmation
+
+Filing an issue publishes public content, same bar as opening a PR - show the user the fully
+rendered title, body, and (if any) sub-issue titles exactly as they'll be created, and **do not
+create anything until they explicitly confirm.** Moving on to another topic is not confirmation.
+
+### 4. Create it
+
+Once confirmed, build a JSON spec and hand it to the bundled script - it creates the issue *and*
+links any sub-issues via GitHub's native sub-issues API (which needs each issue's numeric id, not
+just its number, and can't be done through `gh issue create` flags alone; sub-issues linked this
+way show up as a real progress checklist on the parent, trackable/closable independently):
+
+```json
+{
+  "repo": "<owner>/<repo>",
+  "title": "Add due-date filter to task list endpoint",
+  "body": "## Description\n...\n\n## Acceptance Criteria\n- [ ] ...\n",
+  "labels": ["enhancement", "web"],
+  "sub_issues": [
+    { "title": "Add dueBefore/dueAfter to ListTasksUseCase", "body": "..." },
+    { "title": "Add query params to TaskController", "body": "..." }
+  ]
+}
+```
+
+Write it to a temp file, then run:
+
+```bash
+.claude/skills/github-issues/scripts/create_issue.sh /path/to/spec.json
+```
+
+The script checks `gh auth status` itself and fails with a clear message if not logged in -
+don't attempt to authenticate on the user's behalf, just relay the message. On success it prints
+a JSON summary with the parent URL and each sub-issue URL - relay those links back.
+
+`labels` defaults to none. A label must already exist on the repo before it can be applied -
+check first with `gh label list`; if missing, create it
+(`gh label create "X" --description "..." --color "RRGGBB"`) or ask the user, rather than letting
+the whole script fail partway through.
+
+## Labels
+
+This repo's taxonomy, kept small on purpose:
+
+- **Type**: `bug`, `enhancement`, `refactor`, `docs`, `testing`
+- **Area**: `domain`, `application`, `infrastructure`, `web` - mirrors the onion architecture
+  layers, so `gh issue list --label domain` shows everything touching the Task aggregate
+  regardless of type
+
+Don't invent new labels ad hoc without checking what already exists (`gh label list`).
+
+## Triaging
+
+```bash
+gh issue list                                   # what's open
+gh issue list --label "needs-triage"            # what needs a first pass
+gh issue view <number>                          # read one in full
+gh issue edit <number> --add-label "bug,domain" # label it
+gh issue close <number> --comment "<why>"        # close with a reason, never silently
+```
+
+When triaging a batch: read each issue, propose type + area labels, and apply the unambiguous
+ones. For anything genuinely unclear (unreproducible bug report, vague feature ask), summarize it
+back to the user instead of guessing at a label or closing it - triage should surface judgment
+calls, not paper over them.

--- a/.claude/skills/github-issues/scripts/create_issue.sh
+++ b/.claude/skills/github-issues/scripts/create_issue.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Creates a GitHub issue (and, if present, real linked sub-issues) from a JSON spec.
+#
+# Usage: create_issue.sh <path-to-spec.json>
+#
+# Spec format:
+# {
+#   "repo": "owner/name",
+#   "title": "Parent issue title",
+#   "body": "Parent issue body (markdown)",
+#   "labels": ["optional", "labels"],
+#   "sub_issues": [
+#     { "title": "Sub-issue title", "body": "Sub-issue body (markdown)" }
+#   ]
+# }
+#
+# Sub-issues are linked via GitHub's native sub-issues API (not just mentioned in the body),
+# so they show up as a progress checklist on the parent and can be tracked/closed independently.
+#
+# Prints a JSON summary to stdout:
+# { "parent": "https://github.com/...", "sub_issues": ["https://github.com/...", ...] }
+
+set -euo pipefail
+
+SPEC_FILE="${1:?Usage: create_issue.sh <path-to-spec.json>}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not found" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh is not authenticated. Run 'gh auth login' first." >&2
+  exit 1
+fi
+
+REPO=$(jq -r '.repo' "$SPEC_FILE")
+TITLE=$(jq -r '.title' "$SPEC_FILE")
+LABELS=$(jq -r '.labels // [] | join(",")' "$SPEC_FILE")
+
+BODY_FILE=$(mktemp)
+jq -r '.body' "$SPEC_FILE" > "$BODY_FILE"
+
+CREATE_ARGS=(issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE")
+if [[ -n "$LABELS" ]]; then
+  CREATE_ARGS+=(--label "$LABELS")
+fi
+
+PARENT_URL=$(gh "${CREATE_ARGS[@]}")
+rm -f "$BODY_FILE"
+PARENT_NUMBER=$(basename "$PARENT_URL")
+PARENT_ID=$(gh api "repos/$REPO/issues/$PARENT_NUMBER" --jq '.id')
+
+echo "Created parent issue: $PARENT_URL" >&2
+
+SUB_URLS=()
+SUB_COUNT=$(jq '.sub_issues // [] | length' "$SPEC_FILE")
+
+for ((i = 0; i < SUB_COUNT; i++)); do
+  SUB_TITLE=$(jq -r ".sub_issues[$i].title" "$SPEC_FILE")
+  SUB_BODY_FILE=$(mktemp)
+  jq -r ".sub_issues[$i].body" "$SPEC_FILE" > "$SUB_BODY_FILE"
+
+  SUB_URL=$(gh issue create --repo "$REPO" --title "$SUB_TITLE" --body-file "$SUB_BODY_FILE")
+  rm -f "$SUB_BODY_FILE"
+  SUB_NUMBER=$(basename "$SUB_URL")
+  SUB_ID=$(gh api "repos/$REPO/issues/$SUB_NUMBER" --jq '.id')
+
+  gh api "repos/$REPO/issues/$PARENT_NUMBER/sub_issues" -F sub_issue_id="$SUB_ID" >/dev/null
+
+  echo "Created and linked sub-issue: $SUB_URL" >&2
+  SUB_URLS+=("$SUB_URL")
+done
+
+jq -n --arg parent "$PARENT_URL" --argjson subs "$(printf '%s\n' "${SUB_URLS[@]:-}" | jq -R . | jq -s 'map(select(length > 0))')" \
+  '{parent: $parent, sub_issues: $subs}'

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: github-pr
+description: Open, describe, and update pull requests for the task-manager-api repo, end to end - pushing the branch, writing the description grounded in the real commits, and running gh pr create/edit. Use whenever the user asks to open a PR, create a pull request, "ship this branch", submit work for review, update/refresh an existing PR's description, or wants a PR description written for the current changes.
+---
+
+# Opening a PR in task-manager-api
+
+## Before opening
+
+1. Confirm you're not on `main` (`git branch --show-current`) - a PR needs a feature branch.
+2. Run the full test suite and make sure it's green:
+   ```bash
+   JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw test
+   ```
+   A red PR wastes the reviewer's time. If something is failing and the user wants to open
+   the PR anyway (e.g. to get early feedback on a draft), open it as `--draft` and say so.
+3. Find the base branch rather than assuming `main`:
+   ```bash
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   ```
+4. Read the real commits that will go into the PR - this is the source of truth for the
+   description, not a restatement of the conversation that produced them:
+   ```bash
+   git log --oneline <base>..HEAD
+   git diff <base>...HEAD
+   ```
+   If there are no commits ahead of base, say so and stop rather than opening an empty PR.
+
+## Collecting related issues from the commits
+
+Every commit in this repo carries a `closes|fixes|refs #<N>` reference (the `github-commit`
+skill's format). Scan `git log <base>..HEAD` for those and carry them into the PR body verbatim -
+`closes`/`fixes` stay as closing keywords so GitHub auto-closes the issue on merge, `refs` stays a
+plain reference. Don't invent an issue number if a commit doesn't have one.
+
+## Writing the description
+
+```markdown
+## What
+One or two sentences on what this PR does.
+
+## Related issues
+Closes #<N>
+Refs #<N>
+
+## Changes
+- Bullet points of the specific changes, grouped by area
+- Call out which architecture layer(s) moved: domain / application / infrastructure
+- Mention any files deleted, renamed, or any migration added
+
+## Testing
+How this was verified - e.g. "57 tests pass (`./mvnw verify`, including JaCoCo's coverage
+gate and the ArchUnit rule for X)" or "manually verified via `docker compose up` + curl".
+```
+
+Keep it proportional to the change - a one-file typo fix doesn't need every section filled out
+at length, but don't skip "Related issues" (every commit has one by convention) or "Why" content
+even for small changes; that's the part a reviewer can't get from the diff alone.
+
+Every PR body Claude opens or edits ends with:
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Opening it
+
+Publishing a PR is outward-facing and semi-public (teammates get notified, CI may run) - show
+the user the title and full description before running `gh pr create`, the same way you'd
+confirm before sending a message on someone's behalf. Once confirmed:
+
+```bash
+git push -u origin "$(git branch --show-current)"
+gh pr create --title "<type>: <short summary>" --body "<description>"
+```
+
+For long descriptions, write the body to a temp file and use `--body-file` instead of fighting
+shell quoting. Relay the resulting PR URL back to the user.
+
+If the repo has no `origin` remote or `gh` isn't authenticated (`gh auth status`), say so and
+stop rather than trying to work around it.
+
+## Updating an existing open PR
+
+When more commits land on a branch that already has an open PR, GitHub updates the diff and
+commit list on its own, but **the body does not** - a description written for the earlier state
+goes stale and starts misleading reviewers. Redo the "collecting related issues" and "writing
+the description" steps against the *current* `git log <base>..HEAD`, then:
+
+```bash
+git push
+gh pr edit <number> --title "<title>" --body "<body>"
+```
+
+Find the PR number for the current branch with `gh pr view --json number -q .number` if you
+don't already have it. Same confirmation rule as creation - show the new body first.
+
+## This skill never merges
+
+Opening or updating a PR is as far as this goes. A human reviews and approves every merge in
+this repo - never run `gh pr merge`, never suggest the branch is "ready to merge" as if that's
+your call to make. If the user asks you to merge a PR, tell them that's a step they need to do
+themselves (or explicitly delegate to a human reviewer), not something this skill performs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+The default `java`/`JAVA_HOME` on this machine is not 21. If `./mvnw` picks the wrong JDK, prefix
+every command below with:
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21)
+```
+
+```bash
+./mvnw test                                              # full suite (unit + integration + ArchUnit)
+./mvnw verify                                            # test + JaCoCo coverage gate (85% line/branch)
+./mvnw test -Dtest=TaskTest                              # single test class
+./mvnw test -Dtest='TaskTest$Creation#rejectsBlankTitle' # single method (most tests live in @Nested
+                                                          # classes - plain TaskTest#method silently
+                                                          # runs the whole class instead of filtering)
+./mvnw test -Dtest=OnionArchitectureTest                 # architecture rules only
+./mvnw spring-boot:run                                   # run the app (needs Postgres, see below)
+docker compose up -d                                     # local Postgres for `spring-boot:run`
+```
+
+Persistence tests (`TaskRepositoryAdapterTest`) and the full-context smoke test
+(`TaskManagerApiApplicationTests`) use Testcontainers, which needs Docker running - they spin up
+`postgres:16-alpine` automatically, no manual `docker compose up` needed for `./mvnw test`.
+
+Coverage report after a build: `target/site/jacoco/index.html` (or `jacoco.csv` for a quick
+per-class grep). The check binds to `verify`, not `test` - a plain `mvn test` will not fail the
+build on a coverage drop.
+
+## Architecture
+
+Onion/clean architecture, three layers, dependencies only point inward
+(`infrastructure → application → domain`), enforced by ArchUnit
+(`src/test/java/com/taskmanager/api/architecture/OnionArchitectureTest.java`) - not just a
+convention, a failing test. **`docs/architecture.md` is the canonical, numbered-section
+description of the rules** (layering, domain purity, the three-model separation, package
+placement, patterns, SOLID/GRASP application, testing conventions) - read it before making a
+structural change, and update it if the structure genuinely changes, since
+`.claude/skills/architecture-review` and the `architecture-reviewer` agent read it fresh on
+every review rather than encoding rules of their own.
+
+The shape in one paragraph: `domain` (`Task` aggregate, `TaskStatus`, domain exceptions,
+`TaskRepository` port) has zero framework dependencies and is pure Java. `application` has one
+use case class per operation (`CreateTaskService`, `DeleteTaskService`, ...) implementing
+`UseCase<IN, OUT>`, depending only on the `TaskRepository` port. `infrastructure` holds
+`web` (`TaskController`, DTOs, `GlobalExceptionHandler`) and `persistence`
+(`TaskJpaEntity`, `TaskRepositoryAdapter` implementing the port). `Task` is immutable - every
+transition (`start`/`complete`/`reopen`/`updateDetails`) validates and returns a new instance
+rather than mutating shared state; the legal-transition table lives in `Task` itself, not in a
+service deciding from outside it. Three distinct types exist for "a task"
+(`Task` domain / `TaskJpaEntity` JPA / `TaskResponse` web DTO), translated only at
+`TaskPersistenceMapper` and `TaskWebMapper` - never pass one across a layer it doesn't belong to.
+
+Test pyramid, one style per layer (mirrored by the `unit-tester` agent):
+domain/application tests use plain JUnit 5 + Mockito with **no Spring context**; persistence
+tests use `@DataJpaTest` + Testcontainers against real PostgreSQL (`AbstractPostgresIntegrationTest`
+is the shared container base class - it's a static field, so the container is reused across every
+subclass in the same JVM); web tests use `@WebMvcTest` + MockMvc with use cases mocked.
+
+### Spring Boot 4 gotchas
+
+This targets Spring Boot 4.1.0 (3.5.x hit Maven Central end-of-life June 2026), which
+modularized what used to be one `spring-boot-autoconfigure`/`spring-boot-test-autoconfigure` jar
+into many small per-technology artifacts, and moved to Jackson 3. If something that "should just
+be there" from `spring-boot-starter-test` in a 3.x project doesn't resolve, it's probably one of
+these:
+
+- `@DataJpaTest` → `spring-boot-data-jpa-test`, package `org.springframework.boot.data.jpa.test.autoconfigure`
+- `@AutoConfigureTestDatabase` → `spring-boot-jdbc-test`, package `org.springframework.boot.jdbc.test.autoconfigure`
+- `@WebMvcTest` → `spring-boot-webmvc-test`, package `org.springframework.boot.webmvc.test.autoconfigure`
+- `@MockBean` is gone → use `org.springframework.test.context.bean.override.mockito.MockitoBean`
+- Flyway autoconfiguration needs `spring-boot-starter-flyway`, not just `flyway-core`
+- Jackson: `ObjectMapper` etc. live under `tools.jackson.databind`, not `com.fasterxml.jackson.databind`
+- Testcontainers 2.x renamed modules (`testcontainers-junit-jupiter`, `testcontainers-postgresql`)
+  and moved `PostgreSQLContainer` to `org.testcontainers.postgresql` (non-generic - no `<?>`)
+
+## GitHub workflow
+
+This repo's git/GitHub conventions are encoded as project skills/agents in `.claude/` - they
+trigger automatically, but the one rule worth knowing up front: **every commit must reference a
+GitHub issue** (`<type>(<scope>): <subject>, closes|fixes|refs #<N>` - see
+`.claude/skills/github-commit`). Find or create the issue before committing if one doesn't exist
+yet (`.claude/skills/github-issues`). PRs are opened/updated via `.claude/skills/github-pr` or
+the `pr-manager` agent, always ending with the required footer - **no skill or agent in this repo
+merges a PR**, that's always a human decision.
+
+Delegatable agents (`.claude/agents/`): `task-developer` (implements features),
+`unit-tester` (strengthens coverage against the JaCoCo floor), `architecture-reviewer`
+(read-only conformance + quality review), `pr-manager`, `issue-triager`.
+
+## API
+
+`POST/GET/PUT/DELETE /api/tasks`, `PATCH /api/tasks/{id}/status` with body
+`{"action": "START"|"COMPLETE"|"REOPEN"}`. Status lifecycle: `TODO → IN_PROGRESS → DONE`, plus
+`TODO → DONE` (complete directly) and `DONE → TODO` (reopen); any other transition is
+`409 Conflict`, a missing task is `404`, a domain/validation failure is `400`.


### PR DESCRIPTION
## What
The Claude Code skills/agents that drive this repo's GitHub workflow end to end.

## Related issues
Closes #14, closes #15, closes #16, closes #17, closes #18, closes #13 (all sub-issues of the GitHub-tooling epic are now complete)

## Changes
- `github-commit` skill: mandatory issue-linked commit format (`closes|fixes|refs #N`)
- `github-issues` skill: issue creation with real linked GitHub sub-issues via a bundled script
- `github-pr` skill + `pr-manager` agent: end-to-end PR workflow, explicitly never merges
- `issue-triager` agent: labels only, never closes/deletes
- `CLAUDE.md`: operational guidance for future Claude Code sessions in this repo

## Testing
All 5 commits on this branch were individually verified (no Java code changes - pure `.claude/`/docs additions, `mvn verify` unaffected).

**Note:** supersedes PR #27 (see #29 for context on the retarget-to-main fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)