### PR TITLE
fix: enforce JDK 21 via Maven Toolchains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
-The default `java`/`JAVA_HOME` on this machine is not 21. If `./mvnw` picks the wrong JDK, prefix
-every command below with:
-
-```bash
-JAVA_HOME=$(/usr/libexec/java_home -v 21)
-```
+The build enforces JDK 21 via Maven Toolchains (`maven-toolchains-plugin` in `pom.xml`), so it
+works regardless of the shell's default `java`/`JAVA_HOME` - **but only once `~/.m2/toolchains.xml`
+exists on this machine** (it's per-machine, not part of the repo). One-time setup: copy
+`docs/toolchains.sample.xml` to `~/.m2/toolchains.xml` and point `<jdkHome>` at a JDK 21 install
+(`/usr/libexec/java_home -v 21` on macOS finds one). Without it, every command below fails fast
+with `Cannot find matching toolchain definitions` - a clear error, not a mysterious one, but still
+worth fixing via toolchains.xml rather than routing around it with a manual `JAVA_HOME=` prefix.
 
 ```bash
 ./mvnw test                                              # full suite (unit + integration + ArchUnit)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ valid stricter variant if you want to take it further.
 
 ## Running it
 
+**One-time setup per machine:** this project pins the build to JDK 21 via Maven Toolchains, which
+needs a `~/.m2/toolchains.xml` outside the repo. Copy `docs/toolchains.sample.xml` there and point
+it at your JDK 21 install (see the comments in that file). Without it, `./mvnw` fails fast with a
+clear `Cannot find matching toolchain definitions` error rather than an obscure one.
+
 Start a local Postgres:
 
 ```bash

--- a/docs/toolchains.sample.xml
+++ b/docs/toolchains.sample.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  One-time, per-machine setup so `mvn`/`./mvnw` always builds this project with JDK 21,
+  regardless of whatever JAVA_HOME/java is your shell's default.
+
+  1. Find your JDK 21 install path:
+       /usr/libexec/java_home -v 21          (macOS)
+       update-alternatives --list java       (Linux, then strip the trailing /bin/java)
+     Don't have one? Install it first, e.g. `brew install openjdk@21` on macOS.
+  2. Copy this file to ~/.m2/toolchains.xml (create the ~/.m2/ dir if it doesn't exist).
+  3. Replace the <jdkHome> path below with the path from step 1.
+
+  This file is per-machine, not per-project - it is NOT read from inside this repo, which is
+  why it isn't just `toolchains.xml` at the repo root. Every machine that builds this project
+  needs its own copy at ~/.m2/toolchains.xml once.
+-->
+<toolchains>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>21</version>
+        </provides>
+        <configuration>
+            <jdkHome>/path/to/your/jdk-21</jdkHome>
+        </configuration>
+    </toolchain>
+</toolchains>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,31 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
 
+            <!-- Forces every build to use a JDK 21 toolchain regardless of the shell's ambient
+                 JAVA_HOME/java, and fails fast with a clear message if none is registered -
+                 instead of silently compiling/running with the wrong JDK and failing later with
+                 a confusing bytecode-version mismatch. One-time setup per machine: see
+                 docs/toolchains.sample.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <version>21</version>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
## What
Fixes `./mvnw verify` failing with a class-file-version mismatch when run without `JAVA_HOME` pointed at JDK 21.

## Related issues
Closes #19

## Changes
- `maven-toolchains-plugin`, bound early so a missing toolchain fails fast with a clear message instead of a confusing bytecode-version error
- `docs/toolchains.sample.xml`: committable template for the required (per-machine, outside-the-repo) `~/.m2/toolchains.xml`
- README/CLAUDE.md updated to document the one-time setup instead of the manual `JAVA_HOME=` prefix workaround

## Testing
`mvn clean verify` succeeds with no `JAVA_HOME` override, given `~/.m2/toolchains.xml` is set up. Removing that file produces a clear `Cannot find matching toolchain definitions` failure.

**Note:** supersedes PR #28 (see #29 for context on the retarget-to-main fix). This is the last PR in this batch - `main` will be fully caught up once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)