### PR TITLE
feat: add CI pipeline with build+test, Gitleaks, and Semgrep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
+    # Wait 7 days after a new version is published before proposing it - a newly published
+    # package is more likely to be malicious (not yet caught) or simply unstable.
+    cooldown:
+      default-days: 7
 
   # Actions used in .github/workflows/ci.yml (checkout, setup-java, gitleaks-action, ...).
   - package-ecosystem: github-actions
@@ -16,3 +20,5 @@ updates:
       interval: weekly
     labels:
       - dependencies
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Application and test dependencies (Spring Boot, Testcontainers, ArchUnit, JaCoCo, ...).
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  # Actions used in .github/workflows/ci.yml (checkout, setup-java, gitleaks-action, ...).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        id: setup-java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # The build enforces JDK 21 via Maven Toolchains (see docs/toolchains.sample.xml) so it
+      # can't silently run with the wrong JDK - CI needs its own toolchains.xml pointing at the
+      # JDK setup-java just installed, same as the one-time per-machine setup a human does.
+      - name: Register JDK 21 toolchain
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/toolchains.xml <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <toolchains>
+              <toolchain>
+                  <type>jdk</type>
+                  <provides>
+                      <version>21</version>
+                  </provides>
+                  <configuration>
+                      <jdkHome>${JAVA_HOME}</jdkHome>
+                  </configuration>
+              </toolchain>
+          </toolchains>
+          EOF
+
+      # Testcontainers (persistence tests + the full-context smoke test) needs Docker, which is
+      # preinstalled and running on GitHub-hosted ubuntu runners - no extra setup required.
+      - name: Build and verify (tests + JaCoCo coverage gate)
+        run: ./mvnw --batch-mode clean verify
+
+      - name: Upload JaCoCo report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/
+          retention-days: 14
+
+  secret-scan:
+    name: Secret scan (Gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  sast:
+    name: SAST (Semgrep)
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+      - run: semgrep scan --config=p/java --config=p/owasp-top-ten --config=p/secrets --error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     name: Build & test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up JDK 21
         id: setup-java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: temurin
           java-version: '21'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload JaCoCo report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-report
           path: target/site/jacoco/
@@ -59,10 +59,10 @@ jobs:
     name: Secret scan (Gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -70,7 +70,7 @@ jobs:
     name: SAST (Semgrep)
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.160.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - run: semgrep scan --config=p/java --config=p/owasp-top-ten --config=p/secrets --error

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+title = "task-manager-api gitleaks config"
+
+# Extend the default ruleset rather than replacing it.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known-safe placeholders, not real secrets"
+regexes = [
+  # src/main/resources/application.yml: local-dev-only default credentials for the
+  # docker-compose Postgres instance, matching its POSTGRES_USER/POSTGRES_PASSWORD. Low-entropy,
+  # identical to the username, never used outside a developer's own machine - overridden by real
+  # env vars (DB_USER/DB_PASSWORD) in any other environment.
+  '''\$\{DB_PASSWORD:task_manager\}''',
+]


### PR DESCRIPTION
## What
Adds the automated safety net this repo has been missing: a GitHub Actions pipeline that runs build+test, secret scanning, and SAST on every push/PR to `main`.

## Related issues
Closes #38

## Changes
- `.github/workflows/ci.yml` - three jobs:
  - **build-and-test**: JDK 21 via `actions/setup-java` + a generated `toolchains.xml` (mirrors the local one-time setup from #19), `mvn verify` (full suite + JaCoCo coverage gate), JaCoCo report uploaded as an artifact. Testcontainers works out of the box on GitHub-hosted runners (Docker preinstalled).
  - **secret-scan**: `gitleaks/gitleaks-action`, free for public repos.
  - **sast**: Semgrep with `p/java` + `p/owasp-top-ten` + `p/secrets`.
- `.gitleaks.toml` - allowlists the one known-safe placeholder (the docker-compose-only `DB_PASSWORD` default), with a comment explaining why it's safe.
- `.github/dependabot.yml` - weekly updates for the `maven` and `github-actions` ecosystems (the SCA gate).

## Testing
- `actionlint .github/workflows/ci.yml` - 0 issues.
- Semgrep ruleset tested locally against this codebase before being wired in as a blocking gate - 0 findings, so it's real from day one, not a placeholder.
- `mvn verify` - green locally.
- This is the first PR that will actually exercise these checks - branch protection on `main` already requires all three (`Build & test`, `Secret scan (Gitleaks)`, `SAST (Semgrep)`) to pass before merge.

## Notes for the reviewer
This PR was blocked for a while on a `workflow` OAuth scope requirement (GitHub requires it to push changes under `.github/workflows/`) - that's now resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)